### PR TITLE
feat: Add Philosophy History interactive learning platform

### DIFF
--- a/.factory/droids/learning-tool-generator.md
+++ b/.factory/droids/learning-tool-generator.md
@@ -1,0 +1,329 @@
+# Learning Tool Generator
+
+## Description
+
+Generates interactive learning platforms for new educational topics following the established architecture from the Accounting Fundamentals platform. This droid creates comprehensive, well-structured learning tools with modules, interactive components, quizzes, and progress tracking.
+
+## Activation
+
+Use this droid when:
+- User wants to create a new interactive learning tool
+- User asks to build an educational platform for a new topic
+- User wants to add a study playground for a specific subject
+- Creating curriculum-based learning content
+
+Keywords: learning tool, study playground, educational platform, interactive learning, course builder, curriculum
+
+## Workflow
+
+### Phase 1: Topic Analysis & Planning
+
+1. **Gather Requirements**
+   - What is the learning topic/domain?
+   - Who is the target audience (beginners, intermediate, advanced)?
+   - What are the primary learning goals?
+   - How many modules should the curriculum have?
+   - What interactive tools would be most valuable?
+
+2. **Review Architecture**
+   - Read the abstract specification: `docs/interactive-learning-platform-spec.md`
+   - Study the reference implementation: `src/tools/accounting-intro/`
+   - Understand the project design system: `GUIDELINE.md` and `AGENTS.md`
+
+3. **Create Specification Document**
+   - Draft a spec document at `docs/{topic-slug}-spec.md`
+   - Include:
+     - Overview and vision
+     - Target audience
+     - Curriculum structure (Parts and Modules)
+     - Module details with learning objectives and sections
+     - Interactive tools specification
+     - Technical implementation plan
+   - Get user approval before proceeding
+
+### Phase 2: Scaffold Project Structure
+
+1. **Create Directory Structure**
+   ```
+   src/tools/{topic-slug}/
+   ├── components/
+   │   ├── {Topic}Platform.tsx
+   │   ├── layout/
+   │   ├── content/
+   │   ├── interactive/
+   │   │   ├── calculators/
+   │   │   ├── simulators/
+   │   │   ├── visualizers/
+   │   │   └── assessments/
+   │   ├── charts/
+   │   └── export/
+   ├── content/
+   │   └── quizzes/
+   ├── store/
+   └── types/
+   ```
+
+2. **Create Type Definitions**
+   - Copy and adapt from `src/tools/accounting-intro/types/`
+   - Define domain-specific types
+   - Create module structure with MODULES and PARTS constants
+
+3. **Set Up State Management**
+   - Create progress store with localStorage persistence
+   - Create calculator/data store if needed
+   - Use storage key: `{topic-slug}:progress`
+
+### Phase 3: Build Core Components
+
+1. **Layout Components** (can often reuse from accounting-intro)
+   - ModuleNavigation
+   - ProgressBar
+   - ModuleHeader
+
+2. **Content Components** (can often reuse)
+   - DefinitionCard
+   - KeyTakeaway
+   - ComparisonTable
+   - TryItYourself
+
+3. **Main Platform Shell**
+   - Create `{Topic}Platform.tsx`
+   - Implement module switching with lazy loading
+   - Add responsive sidebar navigation
+   - Include navigation buttons
+
+### Phase 4: Create Module Content
+
+For each module:
+
+1. **Create Module{N}Content.tsx**
+   - Structure with semantic sections
+   - Use content components for definitions, takeaways
+   - Add "Try it yourself" prompts before interactive tools
+   - Include real-world scenarios
+   - Add module summary
+
+2. **Create Quiz Data**
+   - Create `content/quizzes/module-{nn}-quiz.ts`
+   - Include 5-15 questions per module
+   - Mix difficulty levels
+   - Write clear explanations
+   - Export from `content/quizzes/index.ts`
+
+3. **Add Knowledge Check**
+   - Import KnowledgeCheck component
+   - Pass module ID and quiz data
+
+### Phase 5: Build Interactive Tools
+
+For each calculator/simulator/visualizer:
+
+1. **Create Component**
+   - Follow the calculator pattern from spec
+   - Include header with icon, title, reset button
+   - Input section with proper form controls
+   - Results display with visualizations
+   - Use design system tokens
+
+2. **Add Tests**
+   - Create `.test.tsx` file alongside component
+   - Test rendering, user interactions, calculations
+   - Use Vitest and Testing Library
+
+3. **Export and Integrate**
+   - Export from `interactive/index.ts`
+   - Import in relevant module content
+   - Add TryItYourself prompt before tool
+
+### Phase 6: Create Entry Point
+
+1. **Create Astro Page**
+   ```astro
+   ---
+   import Layout from '../../layouts/Layout.astro';
+   import { {Topic}Platform } from '../../tools/{topic-slug}/components/{Topic}Platform';
+   ---
+
+   <Layout title="{Topic Title} | Lifan Dev">
+     <div class="max-w-7xl mx-auto">
+       <{Topic}Platform client:idle />
+     </div>
+   </Layout>
+   ```
+
+2. **Add to Navigation** (if applicable)
+   - Update home page or tools index
+   - Add link card with description
+
+### Phase 7: Testing & Polish
+
+1. **Run Tests**
+   ```bash
+   npm test
+   ```
+
+2. **Verify Functionality**
+   - Test progress tracking persists
+   - Verify quiz completion marks modules
+   - Check responsive design
+   - Test keyboard navigation
+   - Verify accessibility (ARIA labels)
+
+3. **Run Build**
+   ```bash
+   npm run build
+   ```
+
+4. **Create Progress Document**
+   - Create `docs/{topic-slug}-progress.md`
+   - Track implementation status
+
+## Code Examples
+
+### Type Definition Template
+
+```typescript
+// types/module.ts
+export interface Module {
+  id: number;
+  title: string;
+  shortTitle: string;
+  part: number;
+  partTitle: string;
+  description: string;
+  estimatedTime: number;
+  objectives: string[];
+  sections: ModuleSection[];
+}
+
+export const MODULES: Module[] = [
+  {
+    id: 1,
+    title: 'Module Title',
+    shortTitle: 'Short',
+    part: 1,
+    partTitle: 'Part Name',
+    description: 'Description of what this module covers.',
+    estimatedTime: 30,
+    objectives: [
+      'Learning objective 1',
+      'Learning objective 2',
+    ],
+    sections: [
+      { id: '1.1', title: 'Section Title', type: 'content' },
+      { id: '1.2', title: 'Interactive Tool', type: 'interactive' },
+      { id: '1.3', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  // More modules...
+];
+
+export const PARTS = [
+  { id: 1, title: 'Part I: Foundations', modules: [1, 2, 3] },
+  { id: 2, title: 'Part II: Application', modules: [4, 5, 6] },
+];
+```
+
+### Quiz Template
+
+```typescript
+// content/quizzes/module-01-quiz.ts
+import type { QuizQuestion } from '../../types';
+
+export const module01Quiz: QuizQuestion[] = [
+  {
+    id: 'm1-q1',
+    type: 'multiple-choice',
+    question: 'Question text here?',
+    options: [
+      'Option A',
+      'Option B',
+      'Option C',
+      'Option D',
+    ],
+    correctAnswer: 1, // Index of correct option (0-based)
+    explanation: 'Explanation of why this answer is correct.',
+    difficulty: 'easy',
+  },
+  // More questions...
+];
+```
+
+### Calculator Template
+
+```typescript
+// components/interactive/calculators/{Name}Calculator.tsx
+import { Calculator, Plus, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface CalculatorInput {
+  id: string;
+  name: string;
+  value: string;
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function {Name}Calculator() {
+  const [inputs, setInputs] = useState<CalculatorInput[]>([
+    { id: generateId(), name: '', value: '' },
+  ]);
+
+  const results = useMemo(() => {
+    // Calculate results from inputs
+    return { /* computed values */ };
+  }, [inputs]);
+
+  const reset = () => {
+    setInputs([{ id: generateId(), name: '', value: '' }]);
+  };
+
+  return (
+    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+      {/* Header */}
+      <div className="bg-slate-50 dark:bg-slate-800/80 border-b border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Calculator className="w-5 h-5 text-blue-500" />
+          <h3 className="font-semibold text-slate-900 dark:text-white">{Title}</h3>
+        </div>
+        <button
+          onClick={reset}
+          className="text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          Reset
+        </button>
+      </div>
+
+      {/* Input Section */}
+      <div className="p-6">
+        {/* Input fields */}
+      </div>
+
+      {/* Results */}
+      <div className="border-t border-slate-200 dark:border-slate-700 p-6">
+        {/* Results display */}
+      </div>
+    </div>
+  );
+}
+```
+
+## Guidelines
+
+- Follow the project design system (GUIDELINE.md)
+- Use existing components from accounting-intro as templates
+- Write tests for all interactive components
+- Ensure accessibility with proper ARIA labels
+- Use lazy loading for module content
+- Persist progress to localStorage
+- Support both light and dark modes
+- Make all interactive elements mobile-friendly (44px touch targets)
+
+## References
+
+- Abstract Specification: `docs/interactive-learning-platform-spec.md`
+- Reference Implementation: `src/tools/accounting-intro/`
+- Design System: `GUIDELINE.md`
+- Project Guidelines: `AGENTS.md`

--- a/.factory/droids/study-playground-generator.md
+++ b/.factory/droids/study-playground-generator.md
@@ -1,0 +1,281 @@
+# Study Playground Generator
+
+A specialized droid for generating interactive learning tools (study playgrounds) on the Lifan Dev platform.
+
+## When to Use
+
+Invoke this droid when the user wants to:
+- Create a new interactive learning tool/study playground
+- Build an educational platform for a specific topic
+- Generate curriculum structure for a new subject
+- Design interactive calculators, simulators, or visualizers for learning
+
+## Context
+
+This droid generates learning platforms following the established architecture from the Accounting Fundamentals platform. All generated tools should:
+- Follow the modular curriculum structure (Parts > Modules > Sections)
+- Include interactive components embedded in lessons
+- Have knowledge assessments with immediate feedback
+- Track user progress with localStorage persistence
+- Support both light and dark modes
+- Be fully responsive and accessible
+
+## Required Framework References
+
+Before generating any code, the droid MUST read and follow:
+1. `docs/interactive-learning-tool-framework.md` - Complete architecture guide
+2. `docs/interactive-learning-platform-spec.md` - Abstract specification
+3. `GUIDELINE.md` - Design system (colors, typography, spacing)
+4. `AGENTS.md` - Coding conventions and testing requirements
+
+## Reference Implementation
+
+Use the accounting intro platform as the canonical reference:
+- Main component: `src/tools/accounting-intro/components/AccountingPlatform.tsx`
+- Types: `src/tools/accounting-intro/types/`
+- Stores: `src/tools/accounting-intro/store/`
+- Interactive tools: `src/tools/accounting-intro/components/interactive/`
+- Content components: `src/tools/accounting-intro/components/content/`
+
+## Generation Process
+
+### Phase 1: Planning (with user)
+
+1. **Understand the Topic**
+   - What subject/domain should the learning tool cover?
+   - Who is the target audience (beginners, intermediate, advanced)?
+   - What are the key learning objectives?
+
+2. **Define Curriculum Structure**
+   - Break the topic into 3-5 logical parts
+   - Define 6-12 modules total
+   - Estimate learning time per module (30-60 minutes each)
+
+3. **Identify Interactive Components**
+   - What calculators would help illustrate concepts?
+   - What simulations would enable practice?
+   - What visualizations would aid understanding?
+
+4. **Create Spec Document**
+   - Write `docs/{topic-slug}-spec.md` documenting the complete plan
+   - Include module outlines, tool descriptions, and quiz topics
+   - Get user approval before implementation
+
+### Phase 2: Implementation
+
+1. **Set Up Structure**
+   ```
+   src/tools/{topic-slug}/
+   ├── components/
+   │   ├── {Topic}Platform.tsx
+   │   ├── layout/
+   │   ├── content/
+   │   └── interactive/
+   ├── content/
+   │   ├── Module{N}Content.tsx
+   │   └── quizzes/
+   ├── store/
+   └── types/
+   ```
+
+2. **Create Types**
+   - Module definitions with MODULES array
+   - PARTS array for curriculum organization
+   - Domain-specific types for calculators
+
+3. **Build Stores**
+   - Progress store with localStorage persistence
+   - Calculator store if needed for data persistence
+
+4. **Create Platform Shell**
+   - Copy pattern from AccountingPlatform.tsx
+   - Set up lazy loading for module content
+   - Implement navigation and progress tracking
+
+5. **Build Content Components**
+   - Reuse existing components (DefinitionCard, KeyTakeaway, etc.)
+   - Create domain-specific components if needed
+
+6. **Implement Interactive Tools**
+   - Build calculators following the established pattern
+   - Add visualizations using Recharts (lazy-loaded)
+   - Write tests for each interactive component
+
+7. **Create Module Content**
+   - Write Module{N}Content.tsx for each module
+   - Include prose content, interactive tools, and knowledge checks
+   - Write quiz questions (5-15 per module)
+
+8. **Create Astro Page**
+   - Add `src/pages/tools/{topic-slug}.astro`
+   - Use `client:idle` for the platform component
+
+### Phase 3: Testing and Polish
+
+1. **Run All Tests**
+   ```bash
+   npm test
+   ```
+
+2. **Verify TypeScript**
+   ```bash
+   npm run typecheck
+   ```
+
+3. **Test Build**
+   ```bash
+   npm run build
+   ```
+
+4. **Manual Testing**
+   - Test progress persistence
+   - Verify responsive design
+   - Check accessibility (ARIA, focus states)
+
+5. **Create Progress Doc**
+   - Write `docs/{topic-slug}-progress.md` to track implementation status
+
+## File Templates
+
+### Types Template (types/module.ts)
+
+```typescript
+export interface Module {
+  id: number;
+  title: string;
+  shortTitle: string;
+  part: number;
+  partTitle: string;
+  description: string;
+  estimatedTime: number;
+  objectives: string[];
+  sections: ModuleSection[];
+}
+
+export interface ModuleSection {
+  id: string;
+  title: string;
+  type: 'content' | 'interactive' | 'quiz' | 'resources';
+}
+
+export const MODULES: Module[] = [
+  // Define modules here
+];
+
+export const PARTS = [
+  { id: 1, title: 'Part Name', modules: [1, 2, 3] },
+  // Define parts here
+];
+```
+
+### Quiz Template (content/quizzes/module-01-quiz.ts)
+
+```typescript
+import type { QuizQuestion } from '../../types';
+
+export const module01Quiz: QuizQuestion[] = [
+  {
+    id: 'm1-q1',
+    type: 'multiple-choice',
+    question: 'Question text here?',
+    options: [
+      'Option A',
+      'Option B',
+      'Option C',
+      'Option D',
+    ],
+    correctAnswer: 0, // Index of correct option
+    explanation: 'Explanation of why this is the correct answer.',
+    difficulty: 'easy',
+  },
+  // More questions...
+];
+```
+
+### Content Template (content/Module1Content.tsx)
+
+```tsx
+import { ComparisonTable, DefinitionCard, KeyTakeaway } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments/KnowledgeCheck';
+import { module01Quiz } from './quizzes';
+
+export function Module1Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-1-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          1.1 Section Title
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Content here...
+        </p>
+        <DefinitionCard term="Term" definition="Definition..." />
+        <KeyTakeaway>
+          <p>Key point...</p>
+        </KeyTakeaway>
+      </section>
+
+      {/* More sections... */}
+
+      <section id="section-1-quiz" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <KnowledgeCheck
+          moduleId={1}
+          title="Module 1: Section Title"
+          questions={module01Quiz}
+        />
+      </section>
+    </div>
+  );
+}
+```
+
+## Important Guidelines
+
+1. **Always reference the framework docs** before generating code
+2. **Follow the design system** from GUIDELINE.md
+3. **Write tests first** for interactive components
+4. **Use lazy loading** for charts and module content
+5. **Persist data** with Zustand and localStorage
+6. **Support dark mode** in all components
+7. **Ensure accessibility** (ARIA labels, focus states, touch targets)
+8. **Run build and tests** before completing
+
+## Example Invocation
+
+User: "I want to create an interactive study playground for learning basic statistics"
+
+Droid Response:
+1. Read framework documentation
+2. Ask clarifying questions about scope and objectives
+3. Create spec document with curriculum structure
+4. Get user approval
+5. Generate file structure and types
+6. Implement platform shell
+7. Build interactive tools (distribution visualizer, probability calculator, etc.)
+8. Create module content with quizzes
+9. Run tests and verify build
+10. Create progress tracking document
+
+## Commands
+
+The droid should run these commands at appropriate stages:
+
+```bash
+# Install dependencies if new ones are needed
+npm install {package-name}
+
+# Run tests
+npm test
+
+# Type check
+npm run typecheck
+
+# Build
+npm run build
+
+# Dev server (for manual testing)
+npm run dev
+```

--- a/docs/interactive-learning-platform-spec.md
+++ b/docs/interactive-learning-platform-spec.md
@@ -1,0 +1,423 @@
+# Interactive Learning Platform - Abstract Specification
+
+This document defines the abstract architecture for building interactive learning tools on the Lifan Dev platform. It is derived from the successful implementation of the Accounting Fundamentals platform.
+
+---
+
+## Overview
+
+An **Interactive Learning Platform** is a self-contained educational module that combines:
+- Structured curriculum content organized into modules and sections
+- Interactive tools (calculators, simulators, visualizers) embedded within lessons
+- Knowledge assessments with immediate feedback
+- Progress tracking with localStorage persistence
+- Downloadable resources and templates
+
+---
+
+## Core Architecture
+
+### File Structure Template
+
+```
+src/
+├── pages/
+│   └── tools/
+│       └── {topic-slug}.astro           # Landing page with React island
+│
+├── tools/
+│   └── {topic-slug}/
+│       ├── components/
+│       │   ├── {Topic}Platform.tsx      # Main React shell
+│       │   │
+│       │   ├── layout/
+│       │   │   ├── ModuleNavigation.tsx # Sidebar navigation
+│       │   │   ├── ProgressBar.tsx      # Top progress indicator
+│       │   │   └── ModuleHeader.tsx     # Module title, objectives
+│       │   │
+│       │   ├── content/
+│       │   │   ├── DefinitionCard.tsx   # Term definitions
+│       │   │   ├── KeyTakeaway.tsx      # Highlighted key points
+│       │   │   ├── ComparisonTable.tsx  # Side-by-side comparisons
+│       │   │   └── TryItYourself.tsx    # Interactive prompts
+│       │   │
+│       │   ├── interactive/
+│       │   │   ├── calculators/         # Domain-specific calculators
+│       │   │   ├── simulators/          # Interactive simulations
+│       │   │   ├── visualizers/         # Data visualizations
+│       │   │   └── assessments/
+│       │   │       └── KnowledgeCheck.tsx
+│       │   │
+│       │   ├── charts/                  # Lazy-loaded chart components
+│       │   └── export/                  # PDF/CSV export components
+│       │
+│       ├── content/
+│       │   ├── Module{N}Content.tsx     # Module content components
+│       │   └── quizzes/
+│       │       └── module-{nn}-quiz.ts  # Quiz question data
+│       │
+│       ├── store/
+│       │   ├── useProgressStore.ts      # Progress state (Zustand + persist)
+│       │   └── useCalculatorStore.ts    # Calculator data persistence
+│       │
+│       └── types/
+│           ├── index.ts
+│           ├── module.ts                # Module/section definitions
+│           ├── quiz.ts                  # Quiz types
+│           ├── user.ts                  # User progress types
+│           └── domain.ts                # Domain-specific types
+```
+
+---
+
+## Type Definitions
+
+### Module Structure
+
+```typescript
+interface Module {
+  id: number;
+  title: string;
+  shortTitle: string;
+  part: number;
+  partTitle: string;
+  description: string;
+  estimatedTime: number;  // minutes
+  objectives: string[];
+  sections: ModuleSection[];
+}
+
+interface ModuleSection {
+  id: string;            // e.g., '1.1', '2.3'
+  title: string;
+  type: 'content' | 'interactive' | 'quiz' | 'resources';
+}
+
+interface Part {
+  id: number;
+  title: string;
+  modules: number[];     // Module IDs in this part
+}
+```
+
+### Progress Tracking
+
+```typescript
+interface UserProgress {
+  currentModule: number;
+  completedModules: number[];
+  moduleProgress: Record<number, ModuleProgress>;
+  totalTimeSpent: number;
+  lastVisited: string;
+  streak: number;
+  longestStreak: number;
+}
+
+interface ModuleProgress {
+  moduleId: number;
+  sectionsCompleted: string[];
+  quizCompleted: boolean;
+  quizScore: number | null;
+  timeSpent: number;
+  lastAccessed: string;
+}
+```
+
+### Quiz System
+
+```typescript
+interface QuizQuestion {
+  id: string;
+  type: 'multiple-choice' | 'true-false' | 'fill-blank';
+  question: string;
+  options?: string[];
+  correctAnswer: string | number;
+  explanation: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  relatedConcept?: string;
+}
+
+interface QuizAnswer {
+  questionId: string;
+  selectedAnswer: string | number;
+  correct: boolean;
+}
+
+interface QuizResult {
+  score: number;
+  totalQuestions: number;
+  answers: QuizAnswer[];
+  completedAt: string;
+  timeSpent: number;
+}
+```
+
+---
+
+## Component Patterns
+
+### Main Platform Shell
+
+```tsx
+function {Topic}Platform() {
+  const { progress, setCurrentModule } = useProgressStore();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
+      {/* Top Progress Bar */}
+      <div className="sticky top-0 z-40 ...">
+        <ProgressBar />
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        <div className="lg:grid lg:grid-cols-[280px_1fr] lg:gap-8">
+          {/* Sidebar Navigation */}
+          <aside>
+            <ModuleNavigation
+              currentModule={progress.currentModule}
+              onModuleSelect={handleModuleSelect}
+            />
+          </aside>
+
+          {/* Main Content */}
+          <main>
+            <ModuleHeader module={currentModule} />
+            <Suspense fallback={<LoadingFallback />}>
+              {renderModuleContent()}
+            </Suspense>
+            <NavigationButtons />
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### Content Components
+
+**DefinitionCard**: Highlights key terms
+```tsx
+<DefinitionCard
+  term="Term Name"
+  definition="Clear, concise definition of the term."
+/>
+```
+
+**KeyTakeaway**: Emphasizes important concepts
+```tsx
+<KeyTakeaway>
+  <p>The most important point from this section...</p>
+</KeyTakeaway>
+```
+
+**ComparisonTable**: Side-by-side comparisons
+```tsx
+<ComparisonTable
+  headers={['Category', 'Option A', 'Option B']}
+  rows={[
+    ['Feature 1', 'Value A1', 'Value B1'],
+    ['Feature 2', 'Value A2', 'Value B2'],
+  ]}
+/>
+```
+
+**TryItYourself**: Prompts for interactive tools
+```tsx
+<TryItYourself>
+  <p>Use the calculator below to experiment with...</p>
+</TryItYourself>
+```
+
+### Interactive Calculator Pattern
+
+```tsx
+function {Domain}Calculator() {
+  const [data, setData] = useState<CalculatorData>(defaultData);
+  
+  const results = useMemo(() => {
+    // Domain-specific calculations
+    return calculateResults(data);
+  }, [data]);
+
+  return (
+    <div className="bg-white dark:bg-slate-800 border rounded-xl overflow-hidden">
+      {/* Header with title and reset button */}
+      <div className="bg-slate-50 dark:bg-slate-800/80 border-b px-6 py-4 flex justify-between">
+        <div className="flex items-center gap-3">
+          <Icon className="w-5 h-5 text-blue-500" />
+          <h3 className="font-semibold">{title}</h3>
+        </div>
+        <button onClick={reset}>Reset</button>
+      </div>
+
+      {/* Input Section */}
+      <div className="p-6">
+        <InputFields data={data} onChange={setData} />
+      </div>
+
+      {/* Results Display */}
+      <div className="border-t p-6">
+        <ResultsDisplay results={results} />
+      </div>
+    </div>
+  );
+}
+```
+
+### Knowledge Check Pattern
+
+```tsx
+<KnowledgeCheck
+  moduleId={moduleNumber}
+  title="Module X: Topic Name"
+  questions={moduleQuiz}
+  onComplete={(score, total) => {
+    // Optional callback
+  }}
+/>
+```
+
+---
+
+## State Management
+
+### Progress Store (Zustand)
+
+```typescript
+interface ProgressState {
+  progress: UserProgress;
+  setCurrentModule: (moduleId: number) => void;
+  completeModule: (moduleId: number) => void;
+  updateModuleProgress: (moduleId: number, sectionId: string) => void;
+  completeQuiz: (moduleId: number, score: number) => void;
+  addTimeSpent: (seconds: number) => void;
+  resetProgress: () => void;
+}
+
+export const useProgressStore = create<ProgressState>()(
+  persist(
+    (set, get) => ({
+      // Implementation
+    }),
+    {
+      name: '{topic-slug}:progress',
+    }
+  )
+);
+```
+
+### Calculator Store (optional)
+
+For tools that need data persistence across sessions:
+
+```typescript
+interface CalculatorState {
+  data: Record<string, CalculatorData>;
+  setData: (key: string, data: CalculatorData) => void;
+  clearData: (key: string) => void;
+  clearAll: () => void;
+}
+
+export const useCalculatorStore = create<CalculatorState>()(
+  persist(
+    // Implementation
+    { name: '{topic-slug}:data' }
+  )
+);
+```
+
+---
+
+## Technology Stack
+
+| Layer | Technology | Purpose |
+|-------|------------|---------|
+| Framework | Astro + React Islands | Static content with interactive islands |
+| Styling | Tailwind CSS | Design system alignment |
+| State | Zustand + persist | Lightweight, persistent state |
+| Charts | Recharts (lazy-loaded) | Data visualization |
+| Animations | Framer Motion or CSS | Smooth interactions |
+| Forms | React state or react-hook-form | Input handling |
+| PDF Export | @react-pdf/renderer | Downloadable reports |
+| Testing | Vitest + Testing Library | Component and logic tests |
+
+---
+
+## Design Guidelines
+
+Follow the project's design system (GUIDELINE.md):
+
+1. **Colors**: Use design tokens, accent only for CTAs
+2. **Typography**: H1 for module, H2 for sections, H3 for subsections
+3. **Spacing**: 4px base unit, generous whitespace
+4. **Cards**: `.card-lg` for interactive tools
+5. **Transitions**: 200-300ms for micro-interactions
+6. **Accessibility**: ARIA labels, focus states, 44px touch targets
+
+---
+
+## Creating a New Learning Platform
+
+### Step 1: Define Curriculum Structure
+
+1. Identify the subject domain
+2. Break into 4-6 logical parts
+3. Create 8-12 modules total
+4. Define learning objectives for each module
+5. Plan 3-8 sections per module
+
+### Step 2: Design Interactive Tools
+
+For each module, identify:
+- **Calculators**: Tools for computing domain-specific values
+- **Simulators**: Practice scenarios with feedback
+- **Visualizers**: Dynamic representations of concepts
+
+### Step 3: Create Quiz Questions
+
+- 5-15 questions per module
+- Mix of difficulty levels
+- Clear explanations for each answer
+- Cover all module objectives
+
+### Step 4: Implement Components
+
+1. Set up file structure
+2. Create types and stores
+3. Build content components
+4. Implement interactive tools
+5. Add quiz data
+6. Wire up the platform shell
+
+### Step 5: Test and Polish
+
+- Run all unit tests
+- Verify progress persistence
+- Test responsive design
+- Check accessibility
+- Optimize bundle size
+
+---
+
+## Example Domains
+
+This architecture can be applied to various learning topics:
+
+| Domain | Example Modules | Example Tools |
+|--------|-----------------|---------------|
+| **Personal Finance** | Budgeting, Investing, Taxes | Budget Planner, Investment Calculator |
+| **Programming** | Variables, Functions, OOP | Code Runner, Debugger Simulator |
+| **Statistics** | Probability, Distributions, Hypothesis | Distribution Visualizer, Sample Calculator |
+| **Music Theory** | Scales, Chords, Harmony | Scale Builder, Chord Progression Player |
+| **Language Learning** | Grammar, Vocabulary, Conjugation | Verb Conjugator, Vocabulary Quiz |
+| **Chemistry** | Atoms, Bonding, Reactions | Periodic Table Explorer, Reaction Balancer |
+
+---
+
+## References
+
+- Implementation: `src/tools/accounting-intro/`
+- Spec Document: `docs/accounting-intro-spec.md`
+- Progress Tracking: `docs/accounting-intro-progress.md`

--- a/docs/interactive-learning-tool-framework.md
+++ b/docs/interactive-learning-tool-framework.md
@@ -1,0 +1,474 @@
+# Interactive Learning Tool Framework
+
+> **Abstract framework for building educational study playgrounds**
+> 
+> Based on patterns extracted from the Accounting Fundamentals platform
+
+---
+
+## Overview
+
+This framework defines the architecture, patterns, and conventions for building interactive learning tools (study playgrounds) within the Lifan Dev platform. Each learning tool follows a modular, progressive curriculum structure with embedded interactive components.
+
+---
+
+## Core Architecture
+
+### Directory Structure
+
+```
+src/tools/{tool-name}/
+├── components/
+│   ├── {ToolName}Platform.tsx      # Main React shell
+│   ├── layout/                     # Navigation, progress, headers
+│   │   ├── ModuleNavigation.tsx
+│   │   ├── ProgressBar.tsx
+│   │   └── ModuleHeader.tsx
+│   ├── content/                    # Reusable content components
+│   │   ├── DefinitionCard.tsx
+│   │   ├── KeyTakeaway.tsx
+│   │   ├── ComparisonTable.tsx
+│   │   └── TryItYourself.tsx
+│   ├── interactive/                # Interactive tools
+│   │   ├── calculators/            # Data input/output tools
+│   │   ├── simulators/             # Step-by-step simulations
+│   │   ├── visualizers/            # Data visualization
+│   │   └── assessments/            # Quizzes, knowledge checks
+│   ├── charts/                     # Recharts wrappers (lazy-loaded)
+│   └── export/                     # PDF/CSV export functionality
+├── content/
+│   ├── Module{N}Content.tsx        # Module content components
+│   └── quizzes/                    # Quiz data files
+│       └── module-{n}-quiz.ts
+├── store/
+│   ├── useProgressStore.ts         # Progress tracking (Zustand)
+│   └── useCalculatorStore.ts       # Calculator data persistence
+└── types/
+    ├── index.ts
+    ├── module.ts                   # Module, Section definitions
+    ├── quiz.ts                     # Quiz question types
+    ├── user.ts                     # Progress, preferences
+    └── {domain}.ts                 # Domain-specific types
+```
+
+### Astro Page Entry
+
+```astro
+// src/pages/tools/{tool-name}.astro
+---
+import Layout from '../../layouts/Layout.astro';
+import { ToolPlatform } from '../../tools/{tool-name}/components/ToolPlatform';
+---
+
+<Layout title="Tool Title | Lifan Dev">
+  <div class="max-w-7xl mx-auto">
+    <ToolPlatform client:idle />
+  </div>
+</Layout>
+```
+
+---
+
+## Data Models
+
+### Module Definition
+
+```typescript
+interface Module {
+  id: number;
+  title: string;
+  shortTitle: string;
+  part: number;
+  partTitle: string;
+  description: string;
+  estimatedTime: number;  // minutes
+  objectives: string[];
+  sections: ModuleSection[];
+}
+
+interface ModuleSection {
+  id: string;           // e.g., '1.1', '1.2'
+  title: string;
+  type: 'content' | 'interactive' | 'quiz' | 'resources';
+}
+```
+
+### Parts (Curriculum Organization)
+
+```typescript
+const PARTS = [
+  { id: 1, title: 'Part Name', modules: [1, 2, 3] },
+  { id: 2, title: 'Part Name', modules: [4, 5, 6] },
+  // ...
+];
+```
+
+### Quiz Question
+
+```typescript
+interface QuizQuestion {
+  id: string;
+  type: 'multiple-choice' | 'true-false' | 'fill-blank';
+  question: string;
+  options?: string[];
+  correctAnswer: string | number;
+  explanation: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  relatedConcept?: string;
+}
+```
+
+### User Progress
+
+```typescript
+interface UserProgress {
+  currentModule: number;
+  completedModules: number[];
+  moduleProgress: Record<number, ModuleProgress>;
+  totalTimeSpent: number;
+  lastVisited: string;
+  streak: number;
+  longestStreak: number;
+}
+
+interface ModuleProgress {
+  moduleId: number;
+  sectionsCompleted: string[];
+  quizCompleted: boolean;
+  quizScore: number | null;
+  timeSpent: number;
+  lastAccessed: string;
+}
+```
+
+---
+
+## Component Patterns
+
+### Platform Shell
+
+The main platform component manages:
+- Module navigation (sidebar)
+- Progress tracking (top bar)
+- Lazy-loaded module content
+- Previous/Next navigation
+
+```tsx
+export function ToolPlatform() {
+  const { progress, setCurrentModule } = useProgressStore();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
+      {/* Top Progress Bar */}
+      <div className="sticky top-0 z-40 ...">
+        <ProgressBar />
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        <div className="lg:grid lg:grid-cols-[280px_1fr] lg:gap-8">
+          {/* Sidebar */}
+          <aside>
+            <ModuleNavigation
+              currentModule={progress.currentModule}
+              onModuleSelect={handleModuleSelect}
+            />
+          </aside>
+
+          {/* Main Content */}
+          <main>
+            <ModuleHeader module={currentModule} />
+            <Suspense fallback={<ModuleLoadingFallback />}>
+              {renderModuleContent()}
+            </Suspense>
+            {/* Navigation Buttons */}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### Content Components
+
+**DefinitionCard**: Highlight key terms
+```tsx
+<DefinitionCard
+  term="Term Name"
+  definition="Clear explanation of the term."
+/>
+```
+
+**KeyTakeaway**: Emphasize important concepts
+```tsx
+<KeyTakeaway>
+  <p>The most important point from this section...</p>
+</KeyTakeaway>
+```
+
+**ComparisonTable**: Side-by-side comparisons
+```tsx
+<ComparisonTable
+  headers={['Column 1', 'Column 2', 'Column 3']}
+  rows={[
+    ['Row 1 Col 1', 'Row 1 Col 2', 'Row 1 Col 3'],
+    ['Row 2 Col 1', 'Row 2 Col 2', 'Row 2 Col 3'],
+  ]}
+/>
+```
+
+**TryItYourself**: Prompt for interactive tools
+```tsx
+<TryItYourself>
+  Use the calculator below to practice the concept.
+</TryItYourself>
+```
+
+### Calculator Pattern
+
+Calculators are interactive tools for data input/output:
+
+```tsx
+export function SomeCalculator() {
+  const [data, setData] = useState(initialData);
+  const results = useMemo(() => calculate(data), [data]);
+
+  return (
+    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+      {/* Header with title and reset */}
+      <div className="bg-slate-50 dark:bg-slate-800/80 border-b ...">
+        <h3>Calculator Title</h3>
+        <button onClick={reset}>Reset</button>
+      </div>
+
+      <div className="p-6">
+        {/* Input sections */}
+        <InputSection data={data} onChange={setData} />
+        
+        {/* Results display */}
+        <ResultsDisplay results={results} />
+        
+        {/* Visualization (optional) */}
+        <Visualization data={data} results={results} />
+      </div>
+    </div>
+  );
+}
+```
+
+### Assessment Pattern (KnowledgeCheck)
+
+Quiz component with progress tracking:
+
+```tsx
+<KnowledgeCheck
+  moduleId={1}
+  title="Module 1: Topic Name"
+  questions={moduleQuiz}
+  onComplete={(score, total) => { /* optional callback */ }}
+/>
+```
+
+Features:
+- Step-through questions with progress bar
+- Immediate feedback with explanations
+- Score tracking and persistence
+- Retry functionality
+- Auto-completion when score >= 80%
+
+---
+
+## State Management
+
+### Progress Store (Zustand + localStorage)
+
+```typescript
+export const useProgressStore = create<ProgressState>()(
+  persist(
+    (set, get) => ({
+      progress: DEFAULT_PROGRESS,
+      setCurrentModule: (moduleId) => set(...),
+      completeModule: (moduleId) => set(...),
+      completeQuiz: (moduleId, score) => set(...),
+      resetProgress: () => set({ progress: DEFAULT_PROGRESS }),
+    }),
+    { name: '{tool-name}:progress' }
+  )
+);
+```
+
+### Calculator Store (optional)
+
+For persisting calculator data across sessions:
+
+```typescript
+export const useCalculatorStore = create<CalculatorState>()(
+  persist(
+    (set) => ({
+      data: DEFAULT_DATA,
+      updateData: (key, value) => set(...),
+      reset: () => set({ data: DEFAULT_DATA }),
+    }),
+    { name: '{tool-name}:calculator-data' }
+  )
+);
+```
+
+---
+
+## Technology Stack
+
+| Layer | Technology | Usage |
+|-------|------------|-------|
+| Framework | Astro + React Islands | Static content with interactive islands |
+| Styling | Tailwind CSS | Design system compliance |
+| State | Zustand | Lightweight, persistent state |
+| Charts | Recharts (lazy-loaded) | Data visualization |
+| Animations | Framer Motion or CSS | Micro-interactions |
+| Forms | React Hook Form + Zod | Input validation |
+| PDF Export | @react-pdf/renderer | Report generation |
+| Testing | Vitest + Testing Library | Component and logic tests |
+| Icons | Lucide React | Consistent iconography |
+
+---
+
+## Design Guidelines
+
+Follow the project's design system from `GUIDELINE.md`:
+
+1. **Colors**: Neutral backgrounds, accent blue for CTAs only
+2. **Typography**: H1 for module title, H2 for sections, prose for body
+3. **Spacing**: 4px base unit, generous whitespace
+4. **Cards**: `.card-lg` for tools, `.card` for callouts
+5. **Transitions**: 200ms hover, 300ms for sections
+6. **Accessibility**: ARIA labels, focus rings, 44px touch targets
+
+---
+
+## Module Content Template
+
+```tsx
+export function Module{N}Content() {
+  return (
+    <div className="space-y-8">
+      {/* Section X.1 */}
+      <section id="section-{n}-1">
+        <h2>X.1 Section Title</h2>
+        <p>Instructional content...</p>
+        <DefinitionCard term="..." definition="..." />
+        <KeyTakeaway>Key point...</KeyTakeaway>
+      </section>
+
+      {/* Interactive Tool */}
+      <section id="section-{n}-tool">
+        <h2>Interactive Tool</h2>
+        <TryItYourself>Instructions...</TryItYourself>
+        <SomeCalculator />
+      </section>
+
+      {/* Real-World Scenario */}
+      <section id="section-{n}-scenario">
+        <h2>Real-World Scenario</h2>
+        <div className="bg-slate-50 ...">
+          <p className="italic">Scenario description...</p>
+        </div>
+        {/* Discussion points */}
+      </section>
+
+      {/* Summary */}
+      <section id="section-{n}-summary">
+        <h2>Module Summary</h2>
+        <ul>
+          <li>Key learning 1</li>
+          <li>Key learning 2</li>
+        </ul>
+        <p><strong>Next up:</strong> Module X+1...</p>
+      </section>
+
+      {/* Knowledge Check */}
+      <section id="section-{n}-quiz">
+        <h2>Knowledge Check</h2>
+        <KnowledgeCheck moduleId={n} title="..." questions={moduleQuiz} />
+      </section>
+    </div>
+  );
+}
+```
+
+---
+
+## Creating a New Learning Tool
+
+1. **Planning Phase**
+   - Define topic and learning objectives
+   - Structure curriculum into parts and modules
+   - Identify interactive tools needed
+   - Write quiz questions
+
+2. **Setup Phase**
+   - Create directory structure under `src/tools/{tool-name}/`
+   - Define types (modules, quiz, domain-specific)
+   - Set up Zustand stores
+   - Create Astro page entry
+
+3. **Implementation Phase**
+   - Build platform shell with navigation
+   - Create content components (if new ones needed)
+   - Implement module content (ModuleNContent.tsx)
+   - Build interactive calculators/simulators
+   - Write quiz data files
+   - Add charts and visualizations
+
+4. **Polish Phase**
+   - Add PDF/CSV export
+   - Implement responsive design
+   - Accessibility audit
+   - Write tests for interactive components
+
+5. **Integration Phase**
+   - Add to site navigation
+   - Create spec and progress docs
+   - Link from home page if appropriate
+
+---
+
+## Example Tool Ideas
+
+| Topic | Interactive Tools | Key Features |
+|-------|-------------------|--------------|
+| Personal Finance 101 | Budget planner, Savings calculator, Debt payoff tracker | Goal setting, scenario modeling |
+| Basic Statistics | Distribution visualizer, Hypothesis tester, Correlation analyzer | Real-time graphs, sample data |
+| Music Theory | Chord builder, Scale visualizer, Interval trainer | Audio playback, piano keyboard |
+| Photography Basics | Exposure triangle simulator, Composition guides | Image examples, camera settings |
+| Cooking Fundamentals | Recipe scaler, Conversion calculator, Timer | Nutrition facts, substitutions |
+
+---
+
+## Testing Requirements
+
+Per `AGENTS.md`, write tests before implementation for interactive components:
+
+```typescript
+// ComponentName.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ComponentName } from './ComponentName';
+
+describe('ComponentName', () => {
+  it('renders initial state correctly', () => {...});
+  it('handles user input', () => {...});
+  it('calculates results correctly', () => {...});
+  it('validates input', () => {...});
+});
+```
+
+Run tests with: `npm test`
+
+---
+
+## References
+
+- Accounting Intro Implementation: `src/tools/accounting-intro/`
+- Design System: `GUIDELINE.md`
+- Project Guidelines: `AGENTS.md`
+- Spec Example: `docs/accounting-intro-spec.md`

--- a/docs/philosophy-history-spec.md
+++ b/docs/philosophy-history-spec.md
@@ -1,0 +1,430 @@
+# Introduction to Philosophy History - Study Playground Specification
+
+## Overview
+
+A comprehensive interactive learning platform at `/tools/philosophy-intro` that serves as an entry-level educational resource for the history of Western philosophy. This platform guides learners through major philosophical movements, key thinkers, and foundational concepts from ancient Greece to contemporary thought.
+
+The platform combines:
+- **Structured historical narrative** covering 2,500+ years of philosophical development
+- **Interactive timelines and visualizers** showing connections between thinkers and ideas
+- **Concept exploration tools** for understanding philosophical arguments
+- **Thought experiments** that bring abstract ideas to life
+- **Primary source excerpts** with guided analysis
+- **Self-assessment quizzes** to reinforce understanding
+
+---
+
+## Vision Statement
+
+Philosophy shapes how we understand ourselves, society, knowledge, and reality. Yet for many, the history of philosophy seems inaccessible—full of jargon, abstract arguments, and disconnected ideas.
+
+This platform makes philosophical history engaging and approachable by:
+- Presenting ideas in historical and cultural context
+- Connecting ancient questions to modern relevance
+- Using interactive tools to explore philosophical concepts
+- Building a foundation for deeper philosophical study
+
+---
+
+## Target Audience
+
+### Primary Audiences
+
+| Audience | Needs | Success Criteria |
+|----------|-------|------------------|
+| **Complete Beginners** | No philosophy background, curious about big questions | Can identify major philosophers and their key ideas |
+| **College Students** | Intro course supplement or preparation | Understands historical progression and major schools |
+| **Lifelong Learners** | Self-education, intellectual enrichment | Can engage with philosophical texts and discussions |
+| **Professionals** | Context for ethics, logic, critical thinking | Applies philosophical frameworks to real problems |
+
+---
+
+## Curriculum Structure
+
+### Part I: Ancient Philosophy (600 BCE - 500 CE)
+
+**Module 1: The Birth of Philosophy**
+- Pre-Socratic thinkers and the move from myth to reason
+- Thales, Anaximander, Heraclitus, Parmenides
+- The emergence of rational inquiry
+- Interactive: Timeline of Pre-Socratic Thinkers
+
+**Module 2: Socrates and the Examined Life**
+- Socratic method and dialectic
+- Ethics and the pursuit of virtue
+- The trial and death of Socrates
+- Interactive: Socratic Dialogue Simulator
+
+**Module 3: Plato's World of Forms**
+- Theory of Forms and the nature of reality
+- The Republic and ideal society
+- Allegory of the Cave
+- Interactive: Allegory Explorer
+
+**Module 4: Aristotle's Systematic Philosophy**
+- Logic, metaphysics, and categories
+- Ethics and the golden mean
+- Politics and the good life
+- Interactive: Aristotelian Logic Analyzer
+
+### Part II: Medieval & Renaissance Philosophy (500 - 1600)
+
+**Module 5: Faith and Reason**
+- Augustine and Christian philosophy
+- Islamic philosophy: Avicenna and Averroes
+- Jewish philosophy: Maimonides
+- Interactive: Faith-Reason Spectrum
+
+**Module 6: Scholasticism and Aquinas**
+- The medieval university tradition
+- Thomas Aquinas and natural theology
+- Proofs for God's existence
+- Interactive: Argument Mapper
+
+### Part III: Early Modern Philosophy (1600 - 1800)
+
+**Module 7: The Rationalists**
+- Descartes and methodical doubt
+- Spinoza's monism
+- Leibniz and pre-established harmony
+- Interactive: Cartesian Doubt Experiment
+
+**Module 8: The Empiricists**
+- Locke and the blank slate
+- Berkeley's idealism
+- Hume's skepticism
+- Interactive: Empiricism vs Rationalism Comparator
+
+**Module 9: Kant's Critical Philosophy**
+- The Critique of Pure Reason
+- Synthetic a priori judgments
+- Moral philosophy and the categorical imperative
+- Interactive: Kantian Ethics Evaluator
+
+### Part IV: Modern & Contemporary Philosophy (1800 - Present)
+
+**Module 10: 19th Century Revolutions**
+- Hegel and dialectical idealism
+- Marx and historical materialism
+- Nietzsche and the death of God
+- Interactive: Dialectic Visualizer
+
+**Module 11: 20th Century Movements**
+- Existentialism: Kierkegaard to Sartre
+- Phenomenology: Husserl and Heidegger
+- Analytic philosophy: Russell, Wittgenstein
+- Interactive: Philosophical Schools Mapper
+
+**Module 12: Contemporary Questions**
+- Philosophy of mind and consciousness
+- Ethics in the modern world
+- Political philosophy today
+- Interactive: Contemporary Debates Explorer
+
+---
+
+## Interactive Tools Specification
+
+### 1. Philosophy Timeline (Global)
+**Purpose**: Visualize the chronological development of philosophy
+
+**Features:**
+- Zoomable timeline from 600 BCE to present
+- Philosophers positioned by birth/death dates
+- Connections showing influence relationships
+- Filter by school, region, or topic
+- Click to see bio and key ideas
+- Highlight selected philosopher's influences and students
+
+### 2. Socratic Dialogue Simulator
+**Purpose**: Experience the Socratic method firsthand
+
+**Features:**
+- Choose a philosophical topic (justice, knowledge, virtue)
+- AI-style dialogue that asks probing questions
+- Tracks logical consistency of user's positions
+- Shows how contradictions emerge
+- Historical examples from Plato's dialogues
+
+### 3. Allegory of the Cave Explorer
+**Purpose**: Interactive visualization of Plato's famous allegory
+
+**Features:**
+- Animated cave scene with prisoners, shadows, fire
+- Step through stages of enlightenment
+- Connect each stage to Plato's metaphysics
+- Modern examples of "shadows" vs "reality"
+
+### 4. Argument Mapper
+**Purpose**: Visualize philosophical arguments as logical structures
+
+**Features:**
+- Input premises and conclusions
+- Auto-detect argument form (deductive, inductive)
+- Check validity and soundness
+- Pre-loaded famous arguments (cosmological, ontological, etc.)
+- Identify fallacies
+
+### 5. Philosopher Comparison Tool
+**Purpose**: Side-by-side comparison of philosophical positions
+
+**Features:**
+- Select 2-4 philosophers
+- Compare views on: metaphysics, epistemology, ethics, politics
+- Highlight agreements and disagreements
+- Show historical influence between them
+
+### 6. Thought Experiment Simulator
+**Purpose**: Engage with classic philosophical thought experiments
+
+**Features:**
+- Trolley problem and variations
+- Brain in a vat
+- Ship of Theseus
+- Chinese room
+- Track user's intuitions across experiments
+- Show how different philosophers would respond
+
+### 7. Concept Relationship Visualizer
+**Purpose**: Map connections between philosophical concepts
+
+**Features:**
+- Node-graph visualization
+- Concepts as nodes, relationships as edges
+- Filter by era, school, or philosopher
+- Drill down into any concept for definition
+
+### 8. Primary Source Reader
+**Purpose**: Guided reading of philosophical texts
+
+**Features:**
+- Curated excerpts from major works
+- Side-by-side original and modern translation
+- Interactive annotations and explanations
+- Comprehension questions
+- Historical context panel
+
+---
+
+## Technical Implementation
+
+### File Structure
+
+```
+src/tools/philosophy-intro/
+├── components/
+│   ├── PhilosophyPlatform.tsx
+│   ├── layout/
+│   │   ├── ModuleNavigation.tsx
+│   │   ├── ProgressBar.tsx
+│   │   └── ModuleHeader.tsx
+│   ├── content/
+│   │   ├── DefinitionCard.tsx
+│   │   ├── KeyTakeaway.tsx
+│   │   ├── ComparisonTable.tsx
+│   │   ├── TryItYourself.tsx
+│   │   ├── PhilosopherCard.tsx
+│   │   └── QuoteBlock.tsx
+│   ├── interactive/
+│   │   ├── visualizers/
+│   │   │   ├── PhilosophyTimeline.tsx
+│   │   │   ├── ConceptMapper.tsx
+│   │   │   └── AllegoryCaveExplorer.tsx
+│   │   ├── simulators/
+│   │   │   ├── SocraticDialogue.tsx
+│   │   │   ├── ThoughtExperiment.tsx
+│   │   │   └── ArgumentMapper.tsx
+│   │   ├── comparators/
+│   │   │   └── PhilosopherComparison.tsx
+│   │   └── assessments/
+│   │       └── KnowledgeCheck.tsx
+│   └── charts/
+├── content/
+│   ├── Module1Content.tsx through Module12Content.tsx
+│   ├── quizzes/
+│   │   └── module-{01-12}-quiz.ts
+│   └── data/
+│       ├── philosophers.ts
+│       ├── concepts.ts
+│       └── timeline-events.ts
+├── store/
+│   ├── useProgressStore.ts
+│   └── useExplorerStore.ts
+└── types/
+    ├── index.ts
+    ├── module.ts
+    ├── quiz.ts
+    ├── user.ts
+    └── philosophy.ts
+```
+
+### Domain-Specific Types
+
+```typescript
+interface Philosopher {
+  id: string;
+  name: string;
+  birthYear: number;
+  deathYear: number;
+  era: 'ancient' | 'medieval' | 'early-modern' | 'modern' | 'contemporary';
+  school: string[];
+  nationality: string;
+  keyIdeas: string[];
+  majorWorks: Work[];
+  influences: string[];  // philosopher IDs
+  influenced: string[];  // philosopher IDs
+  quotes: Quote[];
+}
+
+interface PhilosophicalConcept {
+  id: string;
+  term: string;
+  definition: string;
+  relatedPhilosophers: string[];
+  relatedConcepts: string[];
+  branch: 'metaphysics' | 'epistemology' | 'ethics' | 'logic' | 'aesthetics' | 'political';
+}
+
+interface ThoughtExperiment {
+  id: string;
+  name: string;
+  philosopher: string;
+  description: string;
+  questions: string[];
+  responses: { philosopher: string; position: string }[];
+}
+
+interface Argument {
+  id: string;
+  name: string;
+  philosopher: string;
+  premises: string[];
+  conclusion: string;
+  type: 'deductive' | 'inductive' | 'abductive';
+  objections: Objection[];
+}
+```
+
+---
+
+## MVP Scope
+
+### MVP (Weeks 1-8)
+
+| Category | Included |
+|----------|----------|
+| **Modules** | All 12 modules with full content |
+| **Core Tools** | Philosophy Timeline, Philosopher Comparison, Argument Mapper |
+| **Assessments** | Knowledge Check quizzes for all modules |
+| **Data** | 50+ philosophers, 100+ concepts |
+
+### Post-MVP (Phase 2)
+
+| Category | Deferred |
+|----------|----------|
+| **Advanced Tools** | Socratic Dialogue Simulator, Thought Experiment Simulator |
+| **Visualizations** | Allegory Cave Explorer, Concept Relationship Graph |
+| **Content** | Primary Source Reader with annotations |
+| **Features** | PDF export of notes, personalized study paths |
+
+---
+
+## Module Learning Objectives
+
+### Module 1: The Birth of Philosophy
+- Explain why philosophy emerged in ancient Greece
+- Identify the key questions asked by Pre-Socratic thinkers
+- Distinguish between mythological and rational explanations
+- Describe the contributions of Thales, Heraclitus, and Parmenides
+
+### Module 2: Socrates and the Examined Life
+- Explain the Socratic method and its purpose
+- Describe Socrates' views on knowledge and virtue
+- Analyze the charges against Socrates and his defense
+- Apply Socratic questioning to contemporary issues
+
+### Module 3: Plato's World of Forms
+- Explain Plato's Theory of Forms
+- Interpret the Allegory of the Cave
+- Describe Plato's view of knowledge vs. opinion
+- Analyze the structure of the ideal state in The Republic
+
+### Module 4: Aristotle's Systematic Philosophy
+- Explain Aristotle's four causes
+- Describe the Golden Mean in ethics
+- Identify the parts of a syllogism
+- Compare Aristotle's approach to Plato's
+
+### Module 5: Faith and Reason
+- Explain Augustine's synthesis of Christianity and Platonism
+- Describe the problem of faith and reason
+- Identify key contributions of Islamic and Jewish philosophy
+- Analyze how ancient philosophy was preserved and transmitted
+
+### Module 6: Scholasticism and Aquinas
+- Explain the scholastic method
+- Analyze Aquinas' Five Ways
+- Distinguish between natural and revealed theology
+- Describe the medieval university tradition
+
+### Module 7: The Rationalists
+- Explain Descartes' method of doubt
+- Analyze the cogito argument
+- Compare rationalist approaches to knowledge
+- Describe Spinoza's and Leibniz's metaphysics
+
+### Module 8: The Empiricists
+- Explain Locke's tabula rasa theory
+- Describe Berkeley's idealism
+- Analyze Hume's skeptical arguments
+- Compare empiricist and rationalist epistemology
+
+### Module 9: Kant's Critical Philosophy
+- Explain the distinction between analytic and synthetic
+- Describe Kant's Copernican Revolution in philosophy
+- Analyze the categorical imperative
+- Explain how Kant synthesized rationalism and empiricism
+
+### Module 10: 19th Century Revolutions
+- Explain Hegel's dialectical method
+- Describe Marx's critique of capitalism
+- Analyze Nietzsche's critique of morality
+- Identify the main reactions against Enlightenment rationalism
+
+### Module 11: 20th Century Movements
+- Distinguish between analytic and continental philosophy
+- Explain existentialist themes in Kierkegaard and Sartre
+- Describe phenomenology's approach to consciousness
+- Analyze Wittgenstein's views on language
+
+### Module 12: Contemporary Questions
+- Identify major debates in philosophy of mind
+- Describe contemporary approaches to ethics
+- Explain key issues in political philosophy
+- Apply philosophical thinking to current issues
+
+---
+
+## Estimated Timeline
+
+| Week | Deliverable |
+|------|-------------|
+| 1 | Project setup, types, stores, platform shell |
+| 2 | Modules 1-3 content + Philosophy Timeline |
+| 3 | Modules 4-6 content + Argument Mapper |
+| 4 | Modules 7-9 content + Philosopher Comparison |
+| 5 | Modules 10-12 content |
+| 6 | All quizzes, knowledge checks |
+| 7 | Polish, accessibility, responsive design |
+| 8 | Testing, bug fixes, documentation |
+
+---
+
+## Success Metrics
+
+- User can navigate all 12 modules
+- Progress persists across sessions
+- All interactive tools function correctly
+- Quiz completion rate tracked
+- Responsive on mobile and desktop
+- Accessible (WCAG AA compliance)

--- a/docs/philosophy-intro-spec.md
+++ b/docs/philosophy-intro-spec.md
@@ -1,0 +1,504 @@
+# Introduction to Philosophy History - Platform Specification
+
+## Overview
+
+A comprehensive educational platform at `/tools/philosophy-intro` that introduces learners to the history of Western philosophy from ancient Greece to modern times. This platform combines rich instructional content with interactive tools that help visualize philosophical timelines, compare ideas across eras, and explore the connections between thinkers.
+
+---
+
+## Vision Statement
+
+Philosophy has shaped human civilization for over 2,500 years, influencing science, politics, ethics, and our understanding of existence. This platform makes philosophy's rich history accessible to beginners by:
+
+- Presenting thinkers chronologically with historical context
+- Breaking down complex ideas into digestible concepts
+- Using interactive tools to visualize connections between philosophers
+- Providing real-world applications of philosophical ideas
+- Building critical thinking skills through Socratic questioning
+
+---
+
+## Target Audience
+
+### Primary Audiences
+
+| Audience | Needs | Success Criteria |
+|----------|-------|------------------|
+| **Complete Beginners** | No philosophy background | Can identify major philosophers and their key ideas |
+| **Students** | Survey course preparation | Ready for introductory philosophy courses |
+| **Lifelong Learners** | Intellectual curiosity | Understand how philosophical ideas evolved and connect |
+| **Professionals** | Critical thinking enhancement | Apply philosophical reasoning to daily decisions |
+
+### Prerequisites
+- No prior philosophy knowledge required
+- Basic reading comprehension
+- Curiosity about ideas and their origins
+
+---
+
+## Curriculum Structure
+
+**Total Modules**: 12
+**Estimated Learning Time**: 10-14 hours (self-paced)
+**Organization**: 4 Parts covering major philosophical eras
+
+---
+
+# PART I: ANCIENT PHILOSOPHY (600 BCE - 300 CE)
+
+## Module 1: The Birth of Philosophy
+
+**Learning Objectives:**
+- Explain what philosophy is and why it emerged in ancient Greece
+- Identify the Pre-Socratic philosophers and their key questions
+- Understand the shift from mythological to rational explanation
+- Recognize the enduring relevance of ancient questions
+
+**Estimated Time**: 40 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 1.1 | What is Philosophy? | content |
+| 1.2 | Why Ancient Greece? | content |
+| 1.3 | The Pre-Socratics | content |
+| 1.4 | Timeline Explorer | interactive |
+| 1.5 | Knowledge Check | quiz |
+
+**Key Concepts:**
+- Philosophy vs. mythology
+- Thales, Anaximander, Heraclitus, Parmenides
+- The question of change vs. permanence
+- Natural philosophy
+
+---
+
+## Module 2: Socrates and the Socratic Method
+
+**Learning Objectives:**
+- Describe Socrates' life and historical significance
+- Explain the Socratic method of questioning
+- Apply Socratic questioning to examine beliefs
+- Understand why Socrates was sentenced to death
+
+**Estimated Time**: 45 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 2.1 | The Life of Socrates | content |
+| 2.2 | "I Know That I Know Nothing" | content |
+| 2.3 | The Socratic Method | content |
+| 2.4 | Socratic Dialogue Simulator | interactive |
+| 2.5 | The Trial and Death of Socrates | content |
+| 2.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Socratic Dialogue Simulator**
+- Present a statement/belief
+- Guide users through questioning steps
+- Reveal assumptions and contradictions
+- Practice critical examination
+
+---
+
+## Module 3: Plato's World of Forms
+
+**Learning Objectives:**
+- Explain Plato's Theory of Forms
+- Interpret the Allegory of the Cave
+- Understand Plato's view of knowledge vs. opinion
+- Describe Plato's ideal state in the Republic
+
+**Estimated Time**: 50 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 3.1 | From Student to Founder | content |
+| 3.2 | The Theory of Forms | content |
+| 3.3 | The Allegory of the Cave | content |
+| 3.4 | Cave Allegory Visualizer | interactive |
+| 3.5 | Plato's Republic | content |
+| 3.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Cave Allegory Visualizer**
+- Animated representation of the cave
+- Stages of enlightenment
+- Modern parallels exploration
+
+---
+
+## Module 4: Aristotle's Systematic Philosophy
+
+**Learning Objectives:**
+- Contrast Aristotle's approach with Plato's
+- Explain Aristotle's four causes
+- Understand virtue ethics and the golden mean
+- Recognize Aristotle's influence on Western thought
+
+**Estimated Time**: 50 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 4.1 | The Student Who Disagreed | content |
+| 4.2 | Logic and Categories | content |
+| 4.3 | The Four Causes | content |
+| 4.4 | Virtue Ethics | content |
+| 4.5 | Philosopher Comparison Tool | interactive |
+| 4.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Philosopher Comparison Tool**
+- Side-by-side comparison of Plato vs. Aristotle
+- Key concepts, methods, conclusions
+- Areas of agreement and disagreement
+
+---
+
+# PART II: MEDIEVAL & EARLY MODERN PHILOSOPHY (400 - 1700)
+
+## Module 5: Medieval Philosophy
+
+**Learning Objectives:**
+- Understand the role of religion in medieval philosophy
+- Explain Augustine's synthesis of Christianity and Platonism
+- Describe Aquinas's Five Ways to prove God's existence
+- Recognize the tension between faith and reason
+
+**Estimated Time**: 45 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 5.1 | Philosophy in the Age of Faith | content |
+| 5.2 | Augustine of Hippo | content |
+| 5.3 | Thomas Aquinas | content |
+| 5.4 | Faith vs. Reason Debate | content |
+| 5.5 | Arguments Analyzer | interactive |
+| 5.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Arguments Analyzer**
+- Break down Aquinas's Five Ways
+- Identify premises and conclusions
+- Evaluate argument strength
+
+---
+
+## Module 6: The Dawn of Modern Philosophy
+
+**Learning Objectives:**
+- Explain Descartes' method of doubt
+- Understand "I think, therefore I am"
+- Contrast rationalism and empiricism
+- Identify the mind-body problem
+
+**Estimated Time**: 50 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 6.1 | The Scientific Revolution | content |
+| 6.2 | Descartes' Method of Doubt | content |
+| 6.3 | Cogito Ergo Sum | content |
+| 6.4 | Rationalism vs. Empiricism | content |
+| 6.5 | Thought Experiment Lab | interactive |
+| 6.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Thought Experiment Lab**
+- Famous thought experiments (evil demon, brain in a vat)
+- Explore implications step by step
+- Test intuitions
+
+---
+
+## Module 7: British Empiricism
+
+**Learning Objectives:**
+- Explain Locke's tabula rasa theory
+- Understand Berkeley's idealism
+- Describe Hume's skepticism about causation
+- Trace the empiricist critique of innate ideas
+
+**Estimated Time**: 45 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 7.1 | Knowledge from Experience | content |
+| 7.2 | John Locke | content |
+| 7.3 | George Berkeley | content |
+| 7.4 | David Hume | content |
+| 7.5 | Empiricism vs. Rationalism Chart | interactive |
+| 7.6 | Knowledge Check | quiz |
+
+---
+
+# PART III: ENLIGHTENMENT TO 19TH CENTURY (1700 - 1900)
+
+## Module 8: Kant's Revolution
+
+**Learning Objectives:**
+- Explain how Kant synthesized rationalism and empiricism
+- Understand the categorical imperative
+- Describe phenomena vs. noumena
+- Recognize Kant's influence on modern ethics
+
+**Estimated Time**: 55 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 8.1 | Awakened from Dogmatic Slumber | content |
+| 8.2 | The Critique of Pure Reason | content |
+| 8.3 | The Categorical Imperative | content |
+| 8.4 | Ethics Decision Analyzer | interactive |
+| 8.5 | Kant's Legacy | content |
+| 8.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Ethics Decision Analyzer**
+- Input an ethical dilemma
+- Apply different ethical frameworks
+- Compare outcomes (Kantian, Utilitarian, Virtue)
+
+---
+
+## Module 9: 19th Century Philosophy
+
+**Learning Objectives:**
+- Explain Hegel's dialectic
+- Understand Nietzsche's critique of morality
+- Describe Marx's historical materialism
+- Recognize the rise of existential themes
+
+**Estimated Time**: 50 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 9.1 | German Idealism | content |
+| 9.2 | Hegel's Dialectic | content |
+| 9.3 | Marx and Historical Materialism | content |
+| 9.4 | Nietzsche's Transvaluation | content |
+| 9.5 | Dialectic Visualizer | interactive |
+| 9.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Dialectic Visualizer**
+- Thesis → Antithesis → Synthesis animation
+- Historical examples
+- Apply to modern debates
+
+---
+
+# PART IV: 20TH CENTURY TO PRESENT
+
+## Module 10: Existentialism
+
+**Learning Objectives:**
+- Define existentialism and its key themes
+- Explain Kierkegaard's leap of faith
+- Understand Sartre's "existence precedes essence"
+- Apply existentialist concepts to personal meaning
+
+**Estimated Time**: 50 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 10.1 | Existence Precedes Essence | content |
+| 10.2 | Kierkegaard: Father of Existentialism | content |
+| 10.3 | Sartre and Radical Freedom | content |
+| 10.4 | Camus and the Absurd | content |
+| 10.5 | Meaning Finder Exercise | interactive |
+| 10.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Meaning Finder Exercise**
+- Guided reflection questions
+- Values clarification
+- Existentialist framework application
+
+---
+
+## Module 11: Analytic Philosophy
+
+**Learning Objectives:**
+- Distinguish analytic from continental philosophy
+- Explain the linguistic turn
+- Understand logical positivism
+- Recognize Wittgenstein's influence
+
+**Estimated Time**: 45 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 11.1 | The Analytic Tradition | content |
+| 11.2 | Russell and Early Analytic Philosophy | content |
+| 11.3 | Wittgenstein's Two Philosophies | content |
+| 11.4 | Logical Positivism | content |
+| 11.5 | Language Analysis Tool | interactive |
+| 11.6 | Knowledge Check | quiz |
+
+**Interactive Tool: Language Analysis Tool**
+- Analyze statements for meaning
+- Identify verifiable vs. non-verifiable claims
+- Clarify ambiguous language
+
+---
+
+## Module 12: Contemporary Philosophy
+
+**Learning Objectives:**
+- Survey major contemporary movements
+- Understand ethics in the modern world
+- Explore philosophy of mind debates
+- Apply philosophical thinking to current issues
+
+**Estimated Time**: 50 minutes
+
+**Sections:**
+| ID | Title | Type |
+|----|-------|------|
+| 12.1 | Philosophy Today | content |
+| 12.2 | Ethics: Utilitarianism to Effective Altruism | content |
+| 12.3 | Philosophy of Mind | content |
+| 12.4 | Political Philosophy | content |
+| 12.5 | Philosophy Timeline Explorer | interactive |
+| 12.6 | Final Assessment | quiz |
+| 12.7 | Where to Go Next | resources |
+
+**Interactive Tool: Philosophy Timeline Explorer**
+- Complete interactive timeline of all philosophers
+- Filter by era, school, topic
+- Visualize influences and connections
+
+---
+
+## Interactive Tools Summary
+
+| Tool | Module | Purpose |
+|------|--------|---------|
+| Timeline Explorer | 1, 12 | Visualize philosophers across history |
+| Socratic Dialogue Simulator | 2 | Practice critical questioning |
+| Cave Allegory Visualizer | 3 | Animate Plato's famous allegory |
+| Philosopher Comparison Tool | 4 | Compare thinkers side-by-side |
+| Arguments Analyzer | 5 | Break down logical arguments |
+| Thought Experiment Lab | 6 | Explore famous thought experiments |
+| Empiricism vs Rationalism Chart | 7 | Compare epistemological approaches |
+| Ethics Decision Analyzer | 8 | Apply ethical frameworks to dilemmas |
+| Dialectic Visualizer | 9 | Understand thesis-antithesis-synthesis |
+| Meaning Finder Exercise | 10 | Personal existentialist reflection |
+| Language Analysis Tool | 11 | Analyze statements for clarity |
+
+---
+
+## Technical Implementation
+
+### File Structure
+
+```
+src/tools/philosophy-intro/
+├── components/
+│   ├── PhilosophyPlatform.tsx
+│   ├── layout/
+│   │   ├── ModuleNavigation.tsx
+│   │   ├── ProgressBar.tsx
+│   │   └── ModuleHeader.tsx
+│   ├── content/
+│   │   ├── DefinitionCard.tsx
+│   │   ├── KeyTakeaway.tsx
+│   │   ├── ComparisonTable.tsx
+│   │   ├── TryItYourself.tsx
+│   │   ├── PhilosopherCard.tsx     # New
+│   │   └── QuoteBlock.tsx           # New
+│   └── interactive/
+│       ├── assessments/
+│       │   └── KnowledgeCheck.tsx
+│       ├── visualizers/
+│       │   ├── TimelineExplorer.tsx
+│       │   ├── CaveAllegoryVisualizer.tsx
+│       │   └── DialecticVisualizer.tsx
+│       └── simulators/
+│           ├── SocraticDialogue.tsx
+│           ├── ThoughtExperimentLab.tsx
+│           ├── EthicsAnalyzer.tsx
+│           └── MeaningFinder.tsx
+├── content/
+│   ├── Module1Content.tsx ... Module12Content.tsx
+│   └── quizzes/
+│       └── module-01-quiz.ts ... module-12-quiz.ts
+├── store/
+│   └── useProgressStore.ts
+├── types/
+│   ├── index.ts
+│   ├── module.ts
+│   ├── quiz.ts
+│   ├── user.ts
+│   └── philosopher.ts
+└── data/
+    └── philosophers.ts
+```
+
+### Domain-Specific Types
+
+```typescript
+interface Philosopher {
+  id: string;
+  name: string;
+  birthYear: number;
+  deathYear: number | null;
+  era: 'ancient' | 'medieval' | 'early-modern' | 'modern' | 'contemporary';
+  school: string[];
+  keyIdeas: string[];
+  influences: string[];      // IDs of philosophers who influenced them
+  influenced: string[];      // IDs of philosophers they influenced
+  quote: string;
+  imageUrl?: string;
+}
+
+interface ThoughtExperiment {
+  id: string;
+  name: string;
+  philosopher: string;
+  description: string;
+  steps: string[];
+  questions: string[];
+  relatedConcepts: string[];
+}
+
+interface EthicalFramework {
+  id: string;
+  name: string;
+  proponent: string;
+  principle: string;
+  howToApply: string[];
+}
+```
+
+---
+
+## MVP Scope
+
+### Phase 1 (MVP)
+- Modules 1-6 (Ancient to Early Modern)
+- Core interactive tools:
+  - Timeline Explorer
+  - Socratic Dialogue Simulator
+  - Philosopher Comparison Tool
+- Progress tracking
+- Knowledge checks for all modules
+
+### Phase 2 (Post-MVP)
+- Modules 7-12
+- Advanced interactive tools
+- PDF export for notes
+- Glossary page
+
+---
+
+## Design Notes
+
+- Use timeline visualization as recurring theme
+- Include philosopher portraits/illustrations where appropriate
+- Quote blocks for primary source excerpts
+- Visual connections between related thinkers
+- Clean, scholarly aesthetic while remaining approachable

--- a/src/pages/tools/philosophy-intro.astro
+++ b/src/pages/tools/philosophy-intro.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { PhilosophyPlatform } from '../../tools/philosophy-intro/components/PhilosophyPlatform';
+---
+
+<Layout title="Introduction to Philosophy History | Lifan Dev">
+  <div class="max-w-7xl mx-auto">
+    <PhilosophyPlatform client:idle />
+  </div>
+</Layout>

--- a/src/tools/philosophy-intro/components/PhilosophyPlatform.tsx
+++ b/src/tools/philosophy-intro/components/PhilosophyPlatform.tsx
@@ -1,0 +1,173 @@
+import { Loader2, Menu, X } from 'lucide-react';
+import { lazy, Suspense, useState } from 'react';
+import { useProgressStore } from '../store';
+import { MODULES } from '../types/module';
+import { ModuleHeader, ModuleNavigation, ProgressBar } from './layout';
+
+const Module1Content = lazy(() => import('../content/Module1Content').then(m => ({ default: m.Module1Content })));
+const Module2Content = lazy(() => import('../content/Module2Content').then(m => ({ default: m.Module2Content })));
+const Module3Content = lazy(() => import('../content/Module3Content').then(m => ({ default: m.Module3Content })));
+const Module4Content = lazy(() => import('../content/Module4Content').then(m => ({ default: m.Module4Content })));
+const Module5Content = lazy(() => import('../content/Module5Content').then(m => ({ default: m.Module5Content })));
+const Module6Content = lazy(() => import('../content/Module6Content').then(m => ({ default: m.Module6Content })));
+const Module7Content = lazy(() => import('../content/Module7Content').then(m => ({ default: m.Module7Content })));
+const Module8Content = lazy(() => import('../content/Module8Content').then(m => ({ default: m.Module8Content })));
+const Module9Content = lazy(() => import('../content/Module9Content').then(m => ({ default: m.Module9Content })));
+const Module10Content = lazy(() => import('../content/Module10Content').then(m => ({ default: m.Module10Content })));
+const Module11Content = lazy(() => import('../content/Module11Content').then(m => ({ default: m.Module11Content })));
+const Module12Content = lazy(() => import('../content/Module12Content').then(m => ({ default: m.Module12Content })));
+
+function ModuleLoadingFallback() {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
+      <span className="ml-3 text-slate-600 dark:text-slate-400">Loading module...</span>
+    </div>
+  );
+}
+
+export function PhilosophyPlatform() {
+  const { progress, setCurrentModule } = useProgressStore();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const currentModule = MODULES.find((m) => m.id === progress.currentModule);
+
+  const handleModuleSelect = (moduleId: number) => {
+    setCurrentModule(moduleId);
+    setSidebarOpen(false);
+  };
+
+  const renderModuleContent = () => {
+    switch (progress.currentModule) {
+      case 0:
+        return (
+          <div className="space-y-6">
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2">
+                Resources & Further Reading
+              </h1>
+              <p className="text-slate-600 dark:text-slate-400">
+                Explore additional resources to deepen your understanding of philosophy.
+              </p>
+            </div>
+            <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-6 border border-slate-200 dark:border-slate-700">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Recommended Books</h2>
+              <ul className="space-y-3 text-slate-700 dark:text-slate-300">
+                <li>Sophie's World by Jostein Gaarder</li>
+                <li>A History of Western Philosophy by Bertrand Russell</li>
+                <li>The Story of Philosophy by Will Durant</li>
+                <li>Philosophy: The Basics by Nigel Warburton</li>
+              </ul>
+            </div>
+          </div>
+        );
+      case 1:
+        return <Module1Content />;
+      case 2:
+        return <Module2Content />;
+      case 3:
+        return <Module3Content />;
+      case 4:
+        return <Module4Content />;
+      case 5:
+        return <Module5Content />;
+      case 6:
+        return <Module6Content />;
+      case 7:
+        return <Module7Content />;
+      case 8:
+        return <Module8Content />;
+      case 9:
+        return <Module9Content />;
+      case 10:
+        return <Module10Content />;
+      case 11:
+        return <Module11Content />;
+      case 12:
+        return <Module12Content />;
+      default:
+        return (
+          <div className="text-center py-12 text-slate-500 dark:text-slate-400">
+            <p className="text-lg">This module is coming soon!</p>
+            <p className="mt-2">Check back later for more content.</p>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
+      <div className="sticky top-0 z-40 bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 px-4 py-3">
+        <div className="max-w-7xl mx-auto flex items-center gap-4">
+          <button
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+            className="lg:hidden p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700"
+            aria-label="Toggle navigation"
+          >
+            {sidebarOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+          </button>
+          <div className="flex-1">
+            <ProgressBar />
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        <div className="lg:grid lg:grid-cols-[280px_1fr] lg:gap-8">
+          <aside
+            className={`
+              fixed inset-y-0 left-0 z-30 w-72 bg-white dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700
+              transform transition-transform duration-200 ease-in-out lg:relative lg:translate-x-0 lg:w-auto lg:border-0 lg:bg-transparent
+              ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+              pt-20 lg:pt-0 px-4 lg:px-0 overflow-y-auto
+            `}
+          >
+            <div className="lg:sticky lg:top-20">
+              <ModuleNavigation
+                currentModule={progress.currentModule}
+                onModuleSelect={handleModuleSelect}
+              />
+            </div>
+          </aside>
+
+          {sidebarOpen && (
+            <button
+              type="button"
+              className="fixed inset-0 z-20 bg-black/50 lg:hidden cursor-default"
+              onClick={() => setSidebarOpen(false)}
+              onKeyDown={(e) => e.key === 'Escape' && setSidebarOpen(false)}
+              aria-label="Close navigation"
+            />
+          )}
+
+          <main className="min-w-0">
+            {currentModule && <ModuleHeader module={currentModule} />}
+
+            <div key={progress.currentModule} className="prose prose-slate dark:prose-invert max-w-none animate-fade-in">
+              <Suspense fallback={<ModuleLoadingFallback />}>
+                {renderModuleContent()}
+              </Suspense>
+            </div>
+
+            <div className="flex justify-between items-center mt-12 pt-8 border-t border-slate-200 dark:border-slate-700">
+              <button
+                onClick={() => handleModuleSelect(Math.max(1, progress.currentModule - 1))}
+                disabled={progress.currentModule === 1}
+                className="px-4 py-3 min-h-[44px] text-sm font-medium rounded-lg border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Previous Module
+              </button>
+              <button
+                onClick={() => handleModuleSelect(Math.min(MODULES.length, progress.currentModule + 1))}
+                disabled={progress.currentModule === MODULES.length}
+                className="px-4 py-3 min-h-[44px] text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Next Module
+              </button>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/ComparisonTable.tsx
+++ b/src/tools/philosophy-intro/components/content/ComparisonTable.tsx
@@ -1,0 +1,42 @@
+interface ComparisonTableProps {
+  headers: string[];
+  rows: string[][];
+}
+
+export function ComparisonTable({ headers, rows }: ComparisonTableProps) {
+  return (
+    <div className="overflow-x-auto my-6">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="bg-slate-100 dark:bg-slate-800">
+            {headers.map((header, index) => (
+              <th
+                key={index}
+                className="px-4 py-3 text-left font-semibold text-slate-900 dark:text-white border border-slate-200 dark:border-slate-700"
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr
+              key={rowIndex}
+              className="bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-800/50"
+            >
+              {row.map((cell, cellIndex) => (
+                <td
+                  key={cellIndex}
+                  className="px-4 py-3 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700"
+                >
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/DefinitionCard.tsx
+++ b/src/tools/philosophy-intro/components/content/DefinitionCard.tsx
@@ -1,0 +1,21 @@
+import { BookOpen } from 'lucide-react';
+
+interface DefinitionCardProps {
+  term: string;
+  definition: string;
+}
+
+export function DefinitionCard({ term, definition }: DefinitionCardProps) {
+  return (
+    <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-5 my-6">
+      <div className="flex items-center gap-2 text-blue-700 dark:text-blue-300 text-sm font-semibold mb-2">
+        <BookOpen className="w-4 h-4" />
+        DEFINITION
+      </div>
+      <p className="text-slate-800 dark:text-slate-200">
+        <strong className="text-slate-900 dark:text-white">{term}:</strong>{' '}
+        {definition}
+      </p>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/KeyTakeaway.tsx
+++ b/src/tools/philosophy-intro/components/content/KeyTakeaway.tsx
@@ -1,0 +1,18 @@
+import { Lightbulb } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface KeyTakeawayProps {
+  children: ReactNode;
+}
+
+export function KeyTakeaway({ children }: KeyTakeawayProps) {
+  return (
+    <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-5 my-6">
+      <div className="flex items-center gap-2 text-amber-700 dark:text-amber-300 text-sm font-semibold mb-2">
+        <Lightbulb className="w-4 h-4" />
+        KEY TAKEAWAY
+      </div>
+      <div className="text-slate-800 dark:text-slate-200">{children}</div>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/PhilosopherCard.tsx
+++ b/src/tools/philosophy-intro/components/content/PhilosopherCard.tsx
@@ -1,0 +1,55 @@
+import { BookMarked, Clock, MapPin, Users } from 'lucide-react';
+
+interface PhilosopherCardProps {
+  name: string;
+  years: string;
+  location: string;
+  school: string;
+  keyIdeas: string[];
+  quote?: string;
+}
+
+export function PhilosopherCard({ name, years, location, school, keyIdeas, quote }: PhilosopherCardProps) {
+  return (
+    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden my-6">
+      <div className="bg-gradient-to-r from-slate-100 to-slate-50 dark:from-slate-800 dark:to-slate-700 px-6 py-4 border-b border-slate-200 dark:border-slate-700">
+        <h4 className="text-xl font-bold text-slate-900 dark:text-white">{name}</h4>
+      </div>
+      
+      <div className="p-6">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+          <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+            <Clock className="w-4 h-4" />
+            <span>{years}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+            <MapPin className="w-4 h-4" />
+            <span>{location}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+            <Users className="w-4 h-4" />
+            <span>{school}</span>
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">
+            <BookMarked className="w-4 h-4" />
+            Key Ideas
+          </div>
+          <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-1">
+            {keyIdeas.map((idea, index) => (
+              <li key={index}>{idea}</li>
+            ))}
+          </ul>
+        </div>
+
+        {quote && (
+          <div className="border-t border-slate-200 dark:border-slate-700 pt-4 mt-4">
+            <p className="text-slate-600 dark:text-slate-400 italic">"{quote}"</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/QuoteBlock.tsx
+++ b/src/tools/philosophy-intro/components/content/QuoteBlock.tsx
@@ -1,0 +1,22 @@
+import { Quote } from 'lucide-react';
+
+interface QuoteBlockProps {
+  quote: string;
+  author: string;
+  source?: string;
+}
+
+export function QuoteBlock({ quote, author, source }: QuoteBlockProps) {
+  return (
+    <blockquote className="border-l-4 border-slate-300 dark:border-slate-600 pl-6 py-4 my-6 bg-slate-50 dark:bg-slate-800/50 rounded-r-lg">
+      <Quote className="w-5 h-5 text-slate-400 dark:text-slate-500 mb-3" />
+      <p className="text-slate-700 dark:text-slate-300 italic text-lg mb-3">
+        "{quote}"
+      </p>
+      <footer className="text-sm text-slate-600 dark:text-slate-400">
+        <cite className="font-medium not-italic">{author}</cite>
+        {source && <span className="ml-1">— {source}</span>}
+      </footer>
+    </blockquote>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/TryItYourself.tsx
+++ b/src/tools/philosophy-intro/components/content/TryItYourself.tsx
@@ -1,0 +1,18 @@
+import { MousePointerClick } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface TryItYourselfProps {
+  children: ReactNode;
+}
+
+export function TryItYourself({ children }: TryItYourselfProps) {
+  return (
+    <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl p-5 my-6">
+      <div className="flex items-center gap-2 text-green-700 dark:text-green-300 text-sm font-semibold mb-2">
+        <MousePointerClick className="w-4 h-4" />
+        TRY IT YOURSELF
+      </div>
+      <div className="text-slate-800 dark:text-slate-200">{children}</div>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/content/index.ts
+++ b/src/tools/philosophy-intro/components/content/index.ts
@@ -1,0 +1,6 @@
+export { ComparisonTable } from './ComparisonTable';
+export { DefinitionCard } from './DefinitionCard';
+export { KeyTakeaway } from './KeyTakeaway';
+export { PhilosopherCard } from './PhilosopherCard';
+export { QuoteBlock } from './QuoteBlock';
+export { TryItYourself } from './TryItYourself';

--- a/src/tools/philosophy-intro/components/interactive/assessments/KnowledgeCheck.tsx
+++ b/src/tools/philosophy-intro/components/interactive/assessments/KnowledgeCheck.tsx
@@ -1,0 +1,212 @@
+import { CheckCircle2, ChevronRight, RotateCcw, XCircle } from 'lucide-react';
+import { useState } from 'react';
+import { useProgressStore } from '../../../store';
+import type { QuizAnswer, QuizQuestion } from '../../../types';
+
+interface KnowledgeCheckProps {
+  moduleId: number;
+  title: string;
+  questions: QuizQuestion[];
+  onComplete?: (score: number, total: number) => void;
+}
+
+export function KnowledgeCheck({ moduleId, title, questions, onComplete }: KnowledgeCheckProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<QuizAnswer[]>([]);
+  const [selectedAnswer, setSelectedAnswer] = useState<string | number | null>(null);
+  const [showExplanation, setShowExplanation] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+
+  const completeQuiz = useProgressStore((s) => s.completeQuiz);
+  const completeModule = useProgressStore((s) => s.completeModule);
+
+  const currentQuestion = questions[currentIndex];
+
+  const handleSelectAnswer = (answer: string | number) => {
+    if (showExplanation) return;
+    setSelectedAnswer(answer);
+  };
+
+  const handleCheckAnswer = () => {
+    if (selectedAnswer === null) return;
+
+    const isCorrect = selectedAnswer === currentQuestion.correctAnswer;
+    const newAnswer: QuizAnswer = {
+      questionId: currentQuestion.id,
+      selectedAnswer,
+      correct: isCorrect,
+    };
+
+    setAnswers([...answers.filter((a) => a.questionId !== currentQuestion.id), newAnswer]);
+    setShowExplanation(true);
+  };
+
+  const handleNext = () => {
+    if (currentIndex < questions.length - 1) {
+      setCurrentIndex(currentIndex + 1);
+      setSelectedAnswer(null);
+      setShowExplanation(false);
+    } else {
+      setIsComplete(true);
+      const correctCount = answers.filter((a) => a.correct).length;
+      const percentage = Math.round((correctCount / questions.length) * 100);
+
+      completeQuiz(moduleId, percentage);
+      if (percentage >= 80) {
+        completeModule(moduleId);
+      }
+
+      onComplete?.(correctCount, questions.length);
+    }
+  };
+
+  const handleRetry = () => {
+    setCurrentIndex(0);
+    setAnswers([]);
+    setSelectedAnswer(null);
+    setShowExplanation(false);
+    setIsComplete(false);
+  };
+
+  const score = answers.filter((a) => a.correct).length;
+  const percentage = Math.round((score / questions.length) * 100);
+
+  if (isComplete) {
+    return (
+      <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden" role="status" aria-live="polite">
+        <div className="bg-slate-50 dark:bg-slate-800/80 border-b border-slate-200 dark:border-slate-700 px-6 py-4">
+          <h3 className="font-semibold text-slate-900 dark:text-white">{title} - Results</h3>
+        </div>
+        <div className="p-8 text-center">
+          <div className={`inline-flex items-center justify-center w-24 h-24 rounded-full mb-4 ${
+            percentage >= 80 ? 'bg-green-100 dark:bg-green-900/30' : percentage >= 60 ? 'bg-amber-100 dark:bg-amber-900/30' : 'bg-red-100 dark:bg-red-900/30'
+          }`}>
+            <span className={`text-3xl font-bold ${
+              percentage >= 80 ? 'text-green-600 dark:text-green-400' : percentage >= 60 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400'
+            }`}>
+              {percentage}%
+            </span>
+          </div>
+          <h4 className="text-xl font-semibold text-slate-900 dark:text-white mb-2">
+            {percentage >= 80 ? 'Excellent!' : percentage >= 60 ? 'Good job!' : 'Keep practicing!'}
+          </h4>
+          <p className="text-slate-600 dark:text-slate-400 mb-6">
+            You got {score} out of {questions.length} questions correct.
+          </p>
+          <div className="flex justify-center gap-3">
+            <button
+              onClick={handleRetry}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Try Again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+      <div className="bg-slate-50 dark:bg-slate-800/80 border-b border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center justify-between">
+        <h3 className="font-semibold text-slate-900 dark:text-white">{title}</h3>
+        <span className="text-sm text-slate-500 dark:text-slate-400">
+          Question {currentIndex + 1} of {questions.length}
+        </span>
+      </div>
+
+      <div className="h-1 bg-slate-200 dark:bg-slate-700">
+        <div
+          className="h-full bg-blue-500 transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / questions.length) * 100}%` }}
+          role="progressbar"
+          aria-valuenow={currentIndex + 1}
+          aria-valuemin={1}
+          aria-valuemax={questions.length}
+          aria-label={`Question ${currentIndex + 1} of ${questions.length}`}
+        />
+      </div>
+
+      <div className="p-6">
+        <p className="text-lg text-slate-900 dark:text-white mb-6">{currentQuestion.question}</p>
+
+        <div className="space-y-3 mb-6">
+          {currentQuestion.options?.map((option, index) => {
+            const isSelected = selectedAnswer === index;
+            const isCorrect = index === currentQuestion.correctAnswer;
+            const showResult = showExplanation;
+
+            let optionClass = 'border-slate-200 dark:border-slate-600 hover:border-blue-300 dark:hover:border-blue-600';
+            if (isSelected && !showResult) {
+              optionClass = 'border-blue-500 bg-blue-50 dark:bg-blue-900/20';
+            } else if (showResult && isCorrect) {
+              optionClass = 'border-green-500 bg-green-50 dark:bg-green-900/20';
+            } else if (showResult && isSelected && !isCorrect) {
+              optionClass = 'border-red-500 bg-red-50 dark:bg-red-900/20';
+            }
+
+            return (
+              <button
+                key={index}
+                onClick={() => handleSelectAnswer(index)}
+                disabled={showExplanation}
+                className={`w-full flex items-center gap-3 p-4 text-left border-2 rounded-lg transition-colors ${optionClass} disabled:cursor-default`}
+              >
+                <span className={`flex items-center justify-center w-6 h-6 rounded-full text-sm font-medium ${
+                  isSelected ? 'bg-blue-500 text-white' : 'bg-slate-200 dark:bg-slate-600 text-slate-600 dark:text-slate-300'
+                }`}>
+                  {String.fromCharCode(65 + index)}
+                </span>
+                <span className="flex-1 text-slate-700 dark:text-slate-300">{option}</span>
+                {showResult && isCorrect && <CheckCircle2 className="w-5 h-5 text-green-500" />}
+                {showResult && isSelected && !isCorrect && <XCircle className="w-5 h-5 text-red-500" />}
+              </button>
+            );
+          })}
+        </div>
+
+        {showExplanation && (
+          <div
+            role="status"
+            aria-live="polite"
+            className={`p-4 rounded-lg mb-6 ${
+              selectedAnswer === currentQuestion.correctAnswer
+                ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800'
+                : 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800'
+            }`}
+          >
+            <p className={`text-sm font-medium mb-1 ${
+              selectedAnswer === currentQuestion.correctAnswer
+                ? 'text-green-700 dark:text-green-300'
+                : 'text-amber-700 dark:text-amber-300'
+            }`}>
+              {selectedAnswer === currentQuestion.correctAnswer ? 'Correct!' : 'Not quite'}
+            </p>
+            <p className="text-sm text-slate-700 dark:text-slate-300">{currentQuestion.explanation}</p>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3">
+          {!showExplanation ? (
+            <button
+              onClick={handleCheckAnswer}
+              disabled={selectedAnswer === null}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Check Answer
+            </button>
+          ) : (
+            <button
+              onClick={handleNext}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              {currentIndex < questions.length - 1 ? 'Next Question' : 'See Results'}
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/interactive/assessments/index.ts
+++ b/src/tools/philosophy-intro/components/interactive/assessments/index.ts
@@ -1,0 +1,1 @@
+export { KnowledgeCheck } from './KnowledgeCheck';

--- a/src/tools/philosophy-intro/components/layout/ModuleHeader.tsx
+++ b/src/tools/philosophy-intro/components/layout/ModuleHeader.tsx
@@ -1,0 +1,49 @@
+import { Clock, Target } from 'lucide-react';
+import type { Module } from '../../types/module';
+
+interface ModuleHeaderProps {
+  module: Module;
+}
+
+export function ModuleHeader({ module }: ModuleHeaderProps) {
+  return (
+    <header className="mb-8">
+      <div className="text-sm text-slate-500 dark:text-slate-400 mb-2">
+        Part {module.part}: {module.partTitle}
+      </div>
+      <h1 className="text-xl sm:text-3xl font-bold text-slate-900 dark:text-white mb-4">
+        Module {module.id}: {module.title}
+      </h1>
+      <p className="text-base sm:text-lg text-slate-600 dark:text-slate-300 mb-6">
+        {module.description}
+      </p>
+
+      <div className="flex items-center gap-6 text-sm text-slate-600 dark:text-slate-400 mb-6">
+        <div className="flex items-center gap-2">
+          <Clock className="w-4 h-4" />
+          <span>{module.estimatedTime} min</span>
+        </div>
+      </div>
+
+      <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-4 sm:p-6 border border-slate-200 dark:border-slate-700">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white mb-4">
+          <Target className="w-4 h-4 text-blue-500" />
+          Learning Objectives
+        </h2>
+        <ul className="space-y-2">
+          {module.objectives.map((objective, index) => (
+            <li
+              key={index}
+              className="flex items-start gap-3 text-sm text-slate-700 dark:text-slate-300"
+            >
+              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 flex items-center justify-center text-xs font-medium">
+                {index + 1}
+              </span>
+              {objective}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </header>
+  );
+}

--- a/src/tools/philosophy-intro/components/layout/ModuleNavigation.tsx
+++ b/src/tools/philosophy-intro/components/layout/ModuleNavigation.tsx
@@ -1,0 +1,91 @@
+import { BookOpen, CheckCircle2, Circle, FolderOpen } from 'lucide-react';
+import { useProgressStore } from '../../store';
+import { MODULES, PARTS } from '../../types/module';
+
+interface ModuleNavigationProps {
+  currentModule: number;
+  onModuleSelect: (moduleId: number) => void;
+}
+
+export function ModuleNavigation({ currentModule, onModuleSelect }: ModuleNavigationProps) {
+  const { progress } = useProgressStore();
+  const { completedModules } = progress;
+
+  const getModuleStatus = (moduleId: number) => {
+    if (completedModules.includes(moduleId)) return 'completed';
+    if (moduleId === currentModule) return 'current';
+    return 'pending';
+  };
+
+  return (
+    <nav className="w-full" aria-label="Module navigation">
+      {PARTS.map((part) => (
+        <div key={part.id} className="mb-6">
+          <h3 className="text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2 flex items-center gap-2">
+            <FolderOpen className="w-4 h-4" />
+            Part {part.id}: {part.title}
+          </h3>
+          <ul className="space-y-1">
+            {part.modules.map((moduleId) => {
+              const module = MODULES.find((m) => m.id === moduleId);
+              if (!module) return null;
+
+              const status = getModuleStatus(moduleId);
+              const isActive = moduleId === currentModule;
+
+              return (
+                <li key={moduleId}>
+                  <button
+                    onClick={() => onModuleSelect(moduleId)}
+                    className={`
+                      w-full flex items-center gap-3 px-3 py-2.5 min-h-[44px] rounded-lg text-left text-sm
+                      transition-colors duration-150
+                      ${isActive
+                        ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 font-medium'
+                        : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
+                      }
+                    `}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {status === 'completed' ? (
+                      <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" />
+                    ) : status === 'current' ? (
+                      <BookOpen className="w-5 h-5 text-blue-500 shrink-0" />
+                    ) : (
+                      <Circle className="w-5 h-5 text-slate-400 dark:text-slate-500 shrink-0" />
+                    )}
+                    <span className="truncate">
+                      {moduleId}. {module.shortTitle}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+
+      <div className="mt-8 pt-6 border-t border-slate-200 dark:border-slate-700">
+        <ul className="space-y-1">
+          <li>
+            <button
+              onClick={() => onModuleSelect(0)}
+              className={`
+                w-full flex items-center gap-3 px-3 py-2.5 min-h-[44px] rounded-lg text-left text-sm
+                transition-colors duration-150
+                ${currentModule === 0
+                  ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 font-medium'
+                  : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
+                }
+              `}
+              aria-current={currentModule === 0 ? 'page' : undefined}
+            >
+              <BookOpen className="w-5 h-5 text-slate-400" />
+              Resources
+            </button>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/src/tools/philosophy-intro/components/layout/ProgressBar.tsx
+++ b/src/tools/philosophy-intro/components/layout/ProgressBar.tsx
@@ -1,0 +1,28 @@
+import { useProgressStore } from '../../store';
+import { MODULES } from '../../types/module';
+
+export function ProgressBar() {
+  const { progress } = useProgressStore();
+  const totalModules = MODULES.length;
+  const completedCount = progress.completedModules.length;
+  const percentage = Math.round((completedCount / totalModules) * 100);
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="flex-1 h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-blue-500 rounded-full transition-all duration-300"
+          style={{ width: `${percentage}%` }}
+          role="progressbar"
+          aria-valuenow={percentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Course progress: ${percentage}%`}
+        />
+      </div>
+      <span className="text-sm font-medium text-slate-600 dark:text-slate-400 whitespace-nowrap">
+        {percentage}% Complete
+      </span>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/components/layout/index.ts
+++ b/src/tools/philosophy-intro/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { ModuleHeader } from './ModuleHeader';
+export { ModuleNavigation } from './ModuleNavigation';
+export { ProgressBar } from './ProgressBar';

--- a/src/tools/philosophy-intro/content/Module10Content.tsx
+++ b/src/tools/philosophy-intro/content/Module10Content.tsx
@@ -1,0 +1,63 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module10Quiz } from './quizzes';
+
+export function Module10Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-10-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">10.1 Existence Precedes Essence</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Existentialism emerged in response to the crises of the 20th century: world wars, totalitarianism, the apparent meaninglessness of mass society. Its central claim: existence precedes essence.</p>
+        <DefinitionCard term="Existence Precedes Essence" definition="We are not born with a fixed nature or purpose. We exist first, then define ourselves through our choices and actions." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">For a hammer, essence precedes existence—someone designs it before making it. But humans have no designer, no preset purpose. We must create our own meaning.</p>
+      </section>
+
+      <section id="section-10-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">10.2 Kierkegaard: Father of Existentialism</h2>
+        <PhilosopherCard name="Soren Kierkegaard" years="1813 - 1855" location="Denmark" school="Existentialism" keyIdeas={['Leap of faith', 'Subjective truth', 'Three stages of existence', 'Anxiety']} quote="Life can only be understood backwards; but it must be lived forwards." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Kierkegaard, a devout Christian, criticized the comfortable Christianity of his day. Genuine faith, he argued, requires a "leap"—a passionate, personal commitment that goes beyond rational proof.</p>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">He described three stages of existence:</p>
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Aesthetic:</strong> Living for pleasure and novelty</li>
+          <li><strong>Ethical:</strong> Living by moral duty and commitment</li>
+          <li><strong>Religious:</strong> Living in passionate relation to God</li>
+        </ul>
+      </section>
+
+      <section id="section-10-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">10.3 Sartre and Radical Freedom</h2>
+        <PhilosopherCard name="Jean-Paul Sartre" years="1905 - 1980" location="France" school="Existentialism" keyIdeas={['Existence precedes essence', 'Radical freedom', 'Bad faith', 'Being and nothingness']} quote="Man is condemned to be free; because once thrown into the world, he is responsible for everything he does." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Sartre developed atheistic existentialism. Without God, there is no human nature defining what we should be. We are "condemned to be free"—there is no escape from choosing.</p>
+        <DefinitionCard term="Bad Faith (Mauvaise foi)" definition="Self-deception where we pretend we have no choice, deny our freedom, or blame circumstances for our actions. It is an attempt to escape the anxiety of freedom." />
+        <QuoteBlock quote="We are left alone, without excuse. That is what I mean when I say that man is condemned to be free." author="Sartre" source="Existentialism Is a Humanism" />
+        <KeyTakeaway><p>For Sartre, to deny our freedom—to say "I had no choice"—is always bad faith. We are responsible for who we become.</p></KeyTakeaway>
+      </section>
+
+      <section id="section-10-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">10.4 Camus and the Absurd</h2>
+        <PhilosopherCard name="Albert Camus" years="1913 - 1960" location="France/Algeria" school="Absurdism" keyIdeas={['The absurd', 'Revolt against meaninglessness', 'Myth of Sisyphus']} quote="One must imagine Sisyphus happy." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Camus focused on the "absurd"—the conflict between our desire for meaning and the universe's silence. He rejected both suicide and religious leaps of faith as responses.</p>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">In "The Myth of Sisyphus," Camus imagines Sisyphus, condemned to roll a boulder up a hill for eternity, as happy. The struggle itself is enough. We must revolt against meaninglessness by embracing life fully.</p>
+        <QuoteBlock quote="The struggle itself toward the heights is enough to fill a man's heart. One must imagine Sisyphus happy." author="Camus" source="The Myth of Sisyphus" />
+      </section>
+
+      <section id="section-10-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Module Summary</h2>
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Existentialism: we define ourselves through choices, not nature</li>
+            <li>Kierkegaard: faith requires a personal leap beyond reason</li>
+            <li>Sartre: we are condemned to be free; bad faith denies this</li>
+            <li>Camus: embrace the absurd and revolt through living fully</li>
+          </ul>
+        </div>
+        <p className="text-slate-700 dark:text-slate-300 mt-6"><strong>Next up:</strong> In Module 11, we explore analytic philosophy's different approach to philosophical problems.</p>
+      </section>
+
+      <section id="section-10-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Knowledge Check</h2>
+        <KnowledgeCheck moduleId={10} title="Module 10: Existentialism" questions={module10Quiz} />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module11Content.tsx
+++ b/src/tools/philosophy-intro/content/Module11Content.tsx
@@ -1,0 +1,55 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module11Quiz } from './quizzes';
+
+export function Module11Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-11-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">11.1 The Analytic Tradition</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">While existentialism flourished on the continent, a different style of philosophy developed in Britain and America: analytic philosophy, focused on language, logic, and clarity.</p>
+        <DefinitionCard term="Analytic Philosophy" definition="A tradition emphasizing clarity, logical analysis, and careful attention to language. It views many philosophical problems as arising from linguistic confusion." />
+      </section>
+
+      <section id="section-11-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">11.2 Russell and Early Analytic Philosophy</h2>
+        <PhilosopherCard name="Bertrand Russell" years="1872 - 1970" location="England" school="Analytic Philosophy" keyIdeas={['Logical atomism', 'Theory of descriptions', 'Principia Mathematica']} quote="The good life is one inspired by love and guided by knowledge." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Russell believed that careful logical analysis could dissolve many philosophical problems. His theory of descriptions showed how to analyze statements about things that don't exist.</p>
+      </section>
+
+      <section id="section-11-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">11.3 Wittgenstein's Two Philosophies</h2>
+        <PhilosopherCard name="Ludwig Wittgenstein" years="1889 - 1951" location="Austria/England" school="Analytic Philosophy" keyIdeas={['Picture theory of meaning', 'Language games', 'Family resemblance', 'Private language argument']} quote="Whereof one cannot speak, thereof one must be silent." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Wittgenstein developed two distinct philosophies:</p>
+        <ComparisonTable headers={['Early Wittgenstein', 'Later Wittgenstein']} rows={[['Language pictures facts', 'Meaning is use'], ['One logical structure', 'Many language games'], ['Clear limits of language', 'Language as social practice'], ['Tractatus Logico-Philosophicus', 'Philosophical Investigations']]} />
+        <KeyTakeaway><p>Later Wittgenstein argued that philosophical problems arise when language "goes on holiday"—when we misuse words outside their normal contexts.</p></KeyTakeaway>
+      </section>
+
+      <section id="section-11-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">11.4 Logical Positivism</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">The Vienna Circle developed logical positivism, which held that meaningful statements must be either analytic (true by definition) or empirically verifiable.</p>
+        <DefinitionCard term="Verification Principle" definition="A statement is meaningful only if it is either analytically true or can in principle be verified by experience. Metaphysical claims, by this standard, are meaningless." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">This threatened to dismiss most of traditional philosophy—ethics, metaphysics, aesthetics—as meaningless. The principle itself faced problems: is it verifiable?</p>
+      </section>
+
+      <section id="section-11-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Module Summary</h2>
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Analytic philosophy emphasizes clarity and logical analysis</li>
+            <li>Russell used logic to dissolve philosophical problems</li>
+            <li>Early Wittgenstein: language pictures reality</li>
+            <li>Later Wittgenstein: meaning is use in language games</li>
+            <li>Logical positivism tried to eliminate metaphysics</li>
+          </ul>
+        </div>
+        <p className="text-slate-700 dark:text-slate-300 mt-6"><strong>Next up:</strong> In Module 12, we survey contemporary philosophy and its relevance today.</p>
+      </section>
+
+      <section id="section-11-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Knowledge Check</h2>
+        <KnowledgeCheck moduleId={11} title="Module 11: Analytic Philosophy" questions={module11Quiz} />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module12Content.tsx
+++ b/src/tools/philosophy-intro/content/Module12Content.tsx
@@ -1,0 +1,69 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module12Quiz } from './quizzes';
+
+export function Module12Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-12-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">12.1 Philosophy Today</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Contemporary philosophy engages with urgent questions: the nature of mind, foundations of ethics, justice in society, and meaning in a scientific age. Let's survey some key areas.</p>
+      </section>
+
+      <section id="section-12-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">12.2 Ethics: From Utilitarianism to Effective Altruism</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Contemporary ethics continues the classical debates while addressing new challenges like global poverty, animal rights, and emerging technologies.</p>
+        <ComparisonTable headers={['Ethical Theory', 'Key Idea', 'Contemporary Advocate']} rows={[['Utilitarianism', 'Maximize overall well-being', 'Peter Singer'], ['Deontology', 'Follow moral rules/duties', 'Christine Korsgaard'], ['Virtue Ethics', 'Cultivate good character', 'Alasdair MacIntyre'], ['Care Ethics', 'Relationships and care', 'Nel Noddings']]} />
+        <DefinitionCard term="Effective Altruism" definition="A philosophical and social movement that uses evidence and reason to determine the most effective ways to benefit others, often focusing on neglected global problems." />
+      </section>
+
+      <section id="section-12-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">12.3 Philosophy of Mind</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">How does the mind relate to the brain? Can consciousness be explained scientifically? These questions are central to contemporary philosophy.</p>
+        <DefinitionCard term="Hard Problem of Consciousness" definition="Why is there subjective experience at all? Even if we explain how the brain processes information, we haven't explained why there is 'something it is like' to be conscious." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Positions range from physicalism (mind is just brain) to dualism (mind is separate) to panpsychism (consciousness is fundamental to reality).</p>
+      </section>
+
+      <section id="section-12-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">12.4 Political Philosophy</h2>
+        <PhilosopherCard name="John Rawls" years="1921 - 2002" location="United States" school="Liberal Political Philosophy" keyIdeas={['Veil of ignorance', 'Original position', 'Justice as fairness']} quote="Justice is the first virtue of social institutions." />
+        <DefinitionCard term="Veil of Ignorance" definition="Rawls's thought experiment: choose principles of justice without knowing your place in society (race, gender, wealth). This ensures fairness." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Contemporary political philosophy debates liberalism, communitarianism, libertarianism, and cosmopolitanism. Questions of global justice, immigration, and democratic legitimacy remain pressing.</p>
+      </section>
+
+      <section id="section-12-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">12.5 Where to Go From Here</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Philosophy continues to ask the big questions. Having completed this introduction, you might explore:</p>
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li>Primary texts by philosophers who interested you most</li>
+          <li>Contemporary debates in ethics, mind, or politics</li>
+          <li>Eastern philosophy: Buddhism, Confucianism, Taoism</li>
+          <li>Applied ethics: bioethics, environmental ethics, AI ethics</li>
+          <li>Philosophy of science, religion, art, or language</li>
+        </ul>
+        <KeyTakeaway><p>Philosophy is not a body of knowledge to memorize but a practice of careful thinking. The goal is not to have all the answers but to ask better questions and examine our assumptions critically.</p></KeyTakeaway>
+      </section>
+
+      <section id="section-12-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Course Summary</h2>
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <p className="text-slate-700 dark:text-slate-300 mb-4">Congratulations on completing Introduction to Philosophy History! You've journeyed through:</p>
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li><strong>Ancient Philosophy:</strong> Pre-Socratics, Socrates, Plato, Aristotle</li>
+            <li><strong>Medieval Philosophy:</strong> Augustine, Aquinas, faith and reason</li>
+            <li><strong>Modern Philosophy:</strong> Descartes, empiricists, Kant</li>
+            <li><strong>19th Century:</strong> Hegel, Marx, Nietzsche</li>
+            <li><strong>20th Century:</strong> Existentialism, analytic philosophy</li>
+            <li><strong>Contemporary:</strong> Ethics, mind, political philosophy</li>
+          </ul>
+        </div>
+        <QuoteBlock quote="The unexamined life is not worth living." author="Socrates" />
+      </section>
+
+      <section id="section-12-7" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Final Assessment</h2>
+        <KnowledgeCheck moduleId={12} title="Module 12: Contemporary Philosophy" questions={module12Quiz} />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module1Content.tsx
+++ b/src/tools/philosophy-intro/content/Module1Content.tsx
@@ -1,0 +1,188 @@
+import { ComparisonTable, DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module01Quiz } from './quizzes';
+
+export function Module1Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-1-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          1.1 What is Philosophy?
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Philosophy is one of humanity's oldest intellectual pursuits. The word itself comes from 
+          the Greek words <em>philos</em> (love) and <em>sophia</em> (wisdom), meaning "love of wisdom."
+        </p>
+
+        <DefinitionCard
+          term="Philosophy"
+          definition="The systematic study of fundamental questions about existence, knowledge, values, reason, mind, and language through rational argument and critical analysis."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Unlike other disciplines that focus on specific domains, philosophy asks the most basic questions:
+        </p>
+
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Metaphysics:</strong> What is the nature of reality? What exists?</li>
+          <li><strong>Epistemology:</strong> What can we know? How do we know it?</li>
+          <li><strong>Ethics:</strong> What should we do? What is good?</li>
+          <li><strong>Logic:</strong> What makes reasoning valid?</li>
+          <li><strong>Aesthetics:</strong> What is beauty? What is art?</li>
+        </ul>
+
+        <KeyTakeaway>
+          <p>
+            Philosophy doesn't give us facts like science does. Instead, it teaches us how to 
+            think critically, examine assumptions, and construct sound arguments. These skills 
+            are valuable in every area of life.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-1-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          1.2 Why Ancient Greece?
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Around 600 BCE, something remarkable happened in the Greek world. Thinkers began 
+          asking questions about nature and seeking <em>natural</em> rather than <em>supernatural</em> explanations.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Before philosophy, people explained the world through myths. Why does the sun move 
+          across the sky? Because the god Helios drives his chariot. Why do seasons change? 
+          Because Persephone goes to the underworld.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The first philosophers asked: What if we could explain these things without invoking 
+          the gods? What if nature follows consistent, discoverable principles?
+        </p>
+
+        <ComparisonTable
+          headers={['Mythological Explanation', 'Philosophical/Natural Explanation']}
+          rows={[
+            ['Zeus throws lightning bolts', 'Lightning is a natural electrical discharge'],
+            ['Poseidon causes earthquakes', 'Earthquakes result from movements in the earth'],
+            ['Gods determine your fate', 'Events follow natural causes'],
+          ]}
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mt-4">
+          Several factors made Greece fertile ground for this new way of thinking:
+        </p>
+
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Trade and travel:</strong> Greeks encountered different cultures and ideas</li>
+          <li><strong>Democracy:</strong> Debate and persuasion were valued skills</li>
+          <li><strong>Leisure class:</strong> Some had time to think beyond daily survival</li>
+          <li><strong>Writing:</strong> Ideas could be recorded and examined</li>
+        </ul>
+      </section>
+
+      <section id="section-1-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          1.3 The Pre-Socratics
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The philosophers before Socrates are called "Pre-Socratics." They asked a fundamental 
+          question: What is the basic substance or principle underlying all of reality?
+        </p>
+
+        <PhilosopherCard
+          name="Thales of Miletus"
+          years="c. 624 - 546 BCE"
+          location="Miletus, Ionia"
+          school="Pre-Socratic"
+          keyIdeas={['Everything is made of water', 'Natural explanations for phenomena', 'First philosopher']}
+          quote="Water is the principle of all things."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Thales proposed that water is the fundamental substance of everything. This seems 
+          naive today, but what matters is that he sought a <em>natural</em> explanation, not a 
+          mythological one.
+        </p>
+
+        <PhilosopherCard
+          name="Heraclitus"
+          years="c. 535 - 475 BCE"
+          location="Ephesus, Ionia"
+          school="Pre-Socratic"
+          keyIdeas={['Everything flows (panta rhei)', 'Fire as the basic element', 'Unity of opposites']}
+          quote="You cannot step into the same river twice."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Heraclitus focused on change. Reality is constantly in flux, like a river. The 
+          apparent stability we see is an illusion.
+        </p>
+
+        <PhilosopherCard
+          name="Parmenides"
+          years="c. 515 - 450 BCE"
+          location="Elea, Italy"
+          school="Pre-Socratic"
+          keyIdeas={['Reality is unchanging', 'Change is an illusion', 'What is, is']}
+          quote="What is, is. What is not, is not."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Parmenides took the opposite view: change is impossible. If something exists, it 
+          cannot come from nothing or become nothing. Therefore, reality must be eternal, 
+          unchanging, and one.
+        </p>
+
+        <KeyTakeaway>
+          <p>
+            The debate between Heraclitus (everything changes) and Parmenides (nothing changes) 
+            set up one of philosophy's most enduring questions: How do we reconcile the appearance 
+            of change with the possibility of stable, knowable reality?
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-1-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Module Summary
+        </h2>
+
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <p className="text-slate-700 dark:text-slate-300 mb-4">
+            In this module, you learned:
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Philosophy means "love of wisdom" and examines fundamental questions</li>
+            <li>Philosophy began in ancient Greece around 600 BCE</li>
+            <li>The Pre-Socratics sought natural rather than mythological explanations</li>
+            <li>Thales, Heraclitus, and Parmenides asked about the basic nature of reality</li>
+            <li>The change vs. permanence debate shaped all later philosophy</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mt-6">
+          <strong>Next up:</strong> In Module 2, you'll meet Socrates, the philosopher who 
+          changed everything by asking questions instead of giving answers.
+        </p>
+      </section>
+
+      <section id="section-1-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6">
+          Test your understanding of the concepts covered in this module.
+        </p>
+        <KnowledgeCheck
+          moduleId={1}
+          title="Module 1: The Birth of Philosophy"
+          questions={module01Quiz}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module2Content.tsx
+++ b/src/tools/philosophy-intro/content/Module2Content.tsx
@@ -1,0 +1,214 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module02Quiz } from './quizzes';
+
+export function Module2Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-2-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          2.1 The Life of Socrates
+        </h2>
+
+        <PhilosopherCard
+          name="Socrates"
+          years="c. 470 - 399 BCE"
+          location="Athens, Greece"
+          school="Classical Greek"
+          keyIdeas={['Socratic method', 'Knowledge is virtue', 'Examined life', 'Intellectual humility']}
+          quote="The unexamined life is not worth living."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Socrates never wrote anything down. Everything we know about him comes from his students, 
+          primarily Plato and Xenophon. He was the son of a stonemason and a midwife, and he spent 
+          his life in the streets and marketplaces of Athens, questioning anyone who would talk to him.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Unlike the Pre-Socratics who focused on nature, Socrates turned philosophy toward 
+          human concerns: How should we live? What is justice? What is virtue?
+        </p>
+
+        <QuoteBlock
+          quote="I cannot teach anybody anything. I can only make them think."
+          author="Socrates"
+          source="as reported by Plato"
+        />
+      </section>
+
+      <section id="section-2-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          2.2 "I Know That I Know Nothing"
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The Oracle at Delphi proclaimed that no one was wiser than Socrates. This puzzled him 
+          because he felt he knew nothing. So he set out to find someone wiser.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          He questioned politicians, poets, and craftsmen. He found that while they claimed 
+          knowledge, under examination their beliefs were confused or contradictory. Socrates 
+          concluded he was indeed wiser, but only because he knew he didn't know.
+        </p>
+
+        <DefinitionCard
+          term="Socratic Wisdom"
+          definition="The recognition that true wisdom begins with acknowledging the limits of one's own knowledge. Knowing that you don't know is the first step toward genuine understanding."
+        />
+
+        <KeyTakeaway>
+          <p>
+            Socratic wisdom isn't about having all the answers. It's about being humble enough 
+            to question what you think you know. This intellectual humility is the starting 
+            point for genuine inquiry.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-2-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          2.3 The Socratic Method
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Socrates developed a distinctive way of doing philosophy through dialogue and questioning, 
+          now called the Socratic method or elenchus.
+        </p>
+
+        <DefinitionCard
+          term="Socratic Method (Elenchus)"
+          definition="A form of cooperative dialogue where questions are asked to stimulate critical thinking, expose contradictions in beliefs, and lead toward deeper understanding."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The method typically works like this:
+        </p>
+
+        <ol className="list-decimal pl-6 space-y-3 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Start with a claim:</strong> Someone asserts they know something (e.g., "Justice is giving people what they deserve")</li>
+          <li><strong>Ask for clarification:</strong> "What do you mean by 'deserve'?"</li>
+          <li><strong>Find counterexamples:</strong> "But what about this case where..."</li>
+          <li><strong>Reveal contradictions:</strong> "Doesn't that contradict what you said earlier?"</li>
+          <li><strong>Refine or abandon:</strong> The person must revise their view or admit ignorance</li>
+        </ol>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Socrates compared himself to a midwife who helps others give birth to ideas. He didn't 
+          claim to have wisdom himself, only to help others discover theirs.
+        </p>
+
+        <KeyTakeaway>
+          <p>
+            The Socratic method isn't about winning arguments. It's about collaborative truth-seeking. 
+            Both participants should be willing to follow the argument wherever it leads.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-2-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          2.4 Virtue and Knowledge
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Socrates held a radical view: virtue is knowledge. If you truly understand what is good, 
+          you will do it. No one does wrong willingly; wrongdoing is always a result of ignorance.
+        </p>
+
+        <QuoteBlock
+          quote="No one errs willingly."
+          author="Socrates"
+          source="Plato's Protagoras"
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          This seems counterintuitive. Don't people sometimes know something is wrong and do it 
+          anyway? Socrates would say that in such cases, they don't truly understand the wrongness. 
+          If they did, they wouldn't do it.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          This connects to his emphasis on self-examination. By questioning our beliefs, we can 
+          discover what is truly good and align our actions with that understanding.
+        </p>
+      </section>
+
+      <section id="section-2-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          2.5 The Trial and Death of Socrates
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          In 399 BCE, at age 70, Socrates was put on trial. The charges were:
+        </p>
+
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Impiety:</strong> Not believing in the gods of Athens</li>
+          <li><strong>Corrupting the youth:</strong> Teaching young people to question authority</li>
+        </ul>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Socrates defended himself but refused to grovel or appeal to emotion. He was found guilty 
+          and sentenced to death by drinking hemlock.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          His friends offered to help him escape, but Socrates refused. He argued that he had 
+          benefited from Athens' laws his whole life, and it would be wrong to break them now 
+          just because the verdict went against him. He accepted his death calmly.
+        </p>
+
+        <QuoteBlock
+          quote="The hour of departure has arrived, and we go our ways — I to die, and you to live. Which is better God only knows."
+          author="Socrates"
+          source="Plato's Apology"
+        />
+
+        <KeyTakeaway>
+          <p>
+            Socrates' death cemented his legacy. He didn't just teach philosophy; he lived and 
+            died by his principles. His willingness to accept death rather than abandon his 
+            commitment to truth and integrity inspired philosophers for millennia.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-2-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Module Summary
+        </h2>
+
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Socrates shifted philosophy from nature to human concerns</li>
+            <li>His wisdom lay in recognizing the limits of his knowledge</li>
+            <li>The Socratic method uses questioning to expose contradictions</li>
+            <li>He believed virtue is knowledge—no one does wrong knowingly</li>
+            <li>He chose death over abandoning his principles</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mt-6">
+          <strong>Next up:</strong> In Module 3, we meet Socrates' most famous student, Plato, 
+          who developed a grand philosophical system including the Theory of Forms.
+        </p>
+      </section>
+
+      <section id="section-2-7" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6">
+          Test your understanding of the concepts covered in this module.
+        </p>
+        <KnowledgeCheck
+          moduleId={2}
+          title="Module 2: Socrates and the Socratic Method"
+          questions={module02Quiz}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module3Content.tsx
+++ b/src/tools/philosophy-intro/content/Module3Content.tsx
@@ -1,0 +1,195 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module03Quiz } from './quizzes';
+
+export function Module3Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-3-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          3.1 From Student to Founder
+        </h2>
+
+        <PhilosopherCard
+          name="Plato"
+          years="c. 428 - 348 BCE"
+          location="Athens, Greece"
+          school="Platonism"
+          keyIdeas={['Theory of Forms', 'Allegory of the Cave', 'Philosopher-kings', 'Immortal soul']}
+          quote="Reality is created by the mind. We can change our reality by changing our mind."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Plato was born into an aristocratic Athenian family. As a young man, he became a devoted 
+          student of Socrates. After Socrates' execution in 399 BCE, Plato traveled widely before 
+          returning to Athens to found the Academy—one of the first institutions of higher learning 
+          in the Western world.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Unlike Socrates, Plato wrote extensively. His works are mostly dialogues featuring Socrates 
+          as the main character. However, many scholars believe that the views expressed, especially 
+          in later dialogues, are Plato's own developments beyond Socrates.
+        </p>
+      </section>
+
+      <section id="section-3-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          3.2 The Theory of Forms
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Plato's most influential idea is the Theory of Forms. He noticed that particular things 
+          in the world are imperfect and changeable. No physical circle is perfectly round. No 
+          act is perfectly just. Yet we can recognize circles and justice. How?
+        </p>
+
+        <DefinitionCard
+          term="Forms (or Ideas)"
+          definition="Perfect, eternal, unchanging templates or essences that exist in a realm beyond the physical world. Physical objects are imperfect copies of these Forms."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          According to Plato, there is a Form of Circularity—a perfect circle that no physical 
+          circle can match but all physical circles approximate. There is a Form of Justice, 
+          Beauty, Goodness, and so on.
+        </p>
+
+        <ComparisonTable
+          headers={['Physical World', 'World of Forms']}
+          rows={[
+            ['Changing', 'Eternal and unchanging'],
+            ['Perceived by senses', 'Grasped by reason'],
+            ['Imperfect copies', 'Perfect originals'],
+            ['Many particulars', 'One Form for each type'],
+            ['Opinion (doxa)', 'Knowledge (episteme)'],
+          ]}
+        />
+
+        <KeyTakeaway>
+          <p>
+            The Forms explain how we can have knowledge in a changing world. While physical 
+            things come and go, the Forms remain eternal. True knowledge is knowledge of the Forms.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-3-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          3.3 The Allegory of the Cave
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          In his most famous passage, from the Republic, Plato illustrates his philosophy with 
+          the Allegory of the Cave.
+        </p>
+
+        <div className="bg-slate-100 dark:bg-slate-800 rounded-xl p-6 my-6">
+          <p className="text-slate-700 dark:text-slate-300 italic mb-4">
+            Imagine prisoners chained in a cave since childhood. They face a wall and cannot turn 
+            around. Behind them is a fire, and between the fire and the prisoners, people carry 
+            objects that cast shadows on the wall.
+          </p>
+          <p className="text-slate-700 dark:text-slate-300 italic mb-4">
+            The prisoners see only shadows and hear only echoes. They believe this is reality. 
+            They give names to the shadows and consider themselves knowledgeable.
+          </p>
+          <p className="text-slate-700 dark:text-slate-300 italic">
+            What if a prisoner were freed and forced to turn around? He would see the fire 
+            and realize the shadows were mere reflections. If dragged outside, he would be 
+            blinded by sunlight but eventually see the sun itself—the source of all light 
+            and life.
+          </p>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The allegory represents Plato's view of reality:
+        </p>
+
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>The prisoners:</strong> Ordinary people trapped in ignorance</li>
+          <li><strong>The shadows:</strong> The physical world we perceive</li>
+          <li><strong>The fire:</strong> The physical sun that illuminates our world</li>
+          <li><strong>The outside world:</strong> The realm of Forms</li>
+          <li><strong>The sun:</strong> The Form of the Good, the highest Form</li>
+        </ul>
+
+        <KeyTakeaway>
+          <p>
+            The Allegory suggests that what we take for reality is like shadows on a wall. 
+            Philosophy is the journey out of the cave—a painful process of enlightenment that 
+            leads to true understanding.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-3-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          3.4 Plato's Republic
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          In the Republic, Plato describes his vision of an ideal society. Just as the individual 
+          soul has three parts (reason, spirit, and appetite), so does the ideal state have 
+          three classes:
+        </p>
+
+        <ComparisonTable
+          headers={['Soul Part', 'Class', 'Virtue', 'Role']}
+          rows={[
+            ['Reason', 'Philosopher-kings', 'Wisdom', 'Rule'],
+            ['Spirit', 'Guardians/Warriors', 'Courage', 'Defend'],
+            ['Appetite', 'Producers', 'Moderation', 'Provide'],
+          ]}
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Plato argued that philosophers should be kings because only they understand the Forms, 
+          especially the Form of the Good. Only those who know what is truly good can govern 
+          well.
+        </p>
+
+        <QuoteBlock
+          quote="Until philosophers rule as kings or those who are now called kings and leading men genuinely and adequately philosophize... cities will have no rest from evils."
+          author="Plato"
+          source="The Republic"
+        />
+      </section>
+
+      <section id="section-3-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Module Summary
+        </h2>
+
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Plato founded the Academy and wrote philosophical dialogues</li>
+            <li>The Theory of Forms posits perfect, eternal templates for all things</li>
+            <li>The Allegory of the Cave illustrates the journey from ignorance to knowledge</li>
+            <li>Knowledge is of Forms; opinion is of the changing physical world</li>
+            <li>Plato envisioned philosopher-kings ruling the ideal state</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mt-6">
+          <strong>Next up:</strong> In Module 4, we meet Aristotle, Plato's brilliant student 
+          who challenged his teacher's ideas and developed his own comprehensive system.
+        </p>
+      </section>
+
+      <section id="section-3-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6">
+          Test your understanding of the concepts covered in this module.
+        </p>
+        <KnowledgeCheck
+          moduleId={3}
+          title="Module 3: Plato's World of Forms"
+          questions={module03Quiz}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module4Content.tsx
+++ b/src/tools/philosophy-intro/content/Module4Content.tsx
@@ -1,0 +1,212 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module04Quiz } from './quizzes';
+
+export function Module4Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-4-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          4.1 The Student Who Disagreed
+        </h2>
+
+        <PhilosopherCard
+          name="Aristotle"
+          years="384 - 322 BCE"
+          location="Athens, Greece (born in Stagira)"
+          school="Aristotelianism"
+          keyIdeas={['Four Causes', 'Golden Mean', 'Formal Logic', 'Virtue Ethics', 'Teleology']}
+          quote="We are what we repeatedly do. Excellence, then, is not an act, but a habit."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Aristotle studied at Plato's Academy for twenty years. After Plato's death, he left 
+          Athens, eventually becoming tutor to Alexander the Great. He later returned to found 
+          his own school, the Lyceum.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          While deeply influenced by Plato, Aristotle disagreed with the Theory of Forms. He 
+          famously said, "Plato is dear to me, but dearer still is truth."
+        </p>
+
+        <QuoteBlock
+          quote="Plato is dear to me, but dearer still is truth."
+          author="Aristotle"
+        />
+      </section>
+
+      <section id="section-4-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          4.2 Logic and Categories
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Aristotle created formal logic. His system of syllogisms was the standard for over 
+          two thousand years.
+        </p>
+
+        <DefinitionCard
+          term="Syllogism"
+          definition="A form of logical argument with two premises and a conclusion. Example: All humans are mortal. Socrates is human. Therefore, Socrates is mortal."
+        />
+
+        <div className="bg-slate-100 dark:bg-slate-800 rounded-xl p-6 my-6">
+          <p className="font-semibold text-slate-900 dark:text-white mb-3">Example Syllogism:</p>
+          <ul className="space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Premise 1: All humans are mortal.</li>
+            <li>Premise 2: Socrates is human.</li>
+            <li className="font-semibold">Conclusion: Therefore, Socrates is mortal.</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Aristotle also developed a system of categories—the most basic ways we can describe 
+          things: substance, quantity, quality, relation, place, time, position, state, action, 
+          and affection.
+        </p>
+      </section>
+
+      <section id="section-4-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          4.3 The Four Causes
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          To fully explain anything, Aristotle said, we must identify its four causes:
+        </p>
+
+        <ComparisonTable
+          headers={['Cause', 'Question', 'Example (Statue)']}
+          rows={[
+            ['Material', 'What is it made of?', 'Bronze'],
+            ['Formal', 'What is its form/structure?', 'Shape of a human'],
+            ['Efficient', 'What made it?', 'The sculptor'],
+            ['Final', 'What is its purpose?', 'To honor a hero'],
+          ]}
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The final cause (purpose or telos) was crucial for Aristotle. Unlike Plato, who placed 
+          Forms in a separate realm, Aristotle believed that form and purpose are inherent in 
+          things themselves.
+        </p>
+
+        <DefinitionCard
+          term="Teleology"
+          definition="The explanation of phenomena by their purposes or goals. Aristotle believed everything in nature has an inherent purpose toward which it strives."
+        />
+      </section>
+
+      <section id="section-4-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          4.4 Virtue Ethics
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          In ethics, Aristotle asked: What is the purpose of human life? His answer: 
+          <strong>eudaimonia</strong>—often translated as "happiness" but better understood as 
+          "flourishing" or "living well."
+        </p>
+
+        <DefinitionCard
+          term="Eudaimonia"
+          definition="Human flourishing or well-being; the highest human good, achieved through living virtuously and exercising reason."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          How do we achieve eudaimonia? Through virtue. And virtue, for Aristotle, is a 
+          <strong>mean between extremes</strong>—the "golden mean."
+        </p>
+
+        <ComparisonTable
+          headers={['Deficiency', 'Virtue (Mean)', 'Excess']}
+          rows={[
+            ['Cowardice', 'Courage', 'Recklessness'],
+            ['Stinginess', 'Generosity', 'Wastefulness'],
+            ['Self-deprecation', 'Truthfulness', 'Boastfulness'],
+            ['Insensibility', 'Temperance', 'Self-indulgence'],
+          ]}
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Virtue is not just about knowing the mean but developing the habit of hitting it. 
+          We become virtuous by practicing virtue, just as we become musicians by playing music.
+        </p>
+
+        <QuoteBlock
+          quote="Virtue is a state of character concerned with choice, lying in a mean relative to us."
+          author="Aristotle"
+          source="Nicomachean Ethics"
+        />
+
+        <KeyTakeaway>
+          <p>
+            Aristotle's ethics is about character, not rules. The virtuous person doesn't just 
+            do the right thing; they do it at the right time, in the right way, for the right 
+            reasons, and they enjoy doing it.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-4-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          4.5 Plato vs. Aristotle
+        </h2>
+
+        <ComparisonTable
+          headers={['Topic', 'Plato', 'Aristotle']}
+          rows={[
+            ['Forms', 'Exist in separate realm', 'Exist within particular things'],
+            ['Knowledge', 'Recollection of Forms', 'Abstraction from experience'],
+            ['Method', 'Dialectic, mathematics', 'Observation, classification'],
+            ['Focus', 'Eternal, unchanging', 'Change, development'],
+            ['Politics', 'Philosopher-kings', 'Mixed constitution'],
+          ]}
+        />
+
+        <KeyTakeaway>
+          <p>
+            Plato looked upward to eternal Forms; Aristotle looked around at the natural world. 
+            Both approaches have shaped Western thought profoundly.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-4-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Module Summary
+        </h2>
+
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Aristotle developed formal logic through syllogisms</li>
+            <li>The Four Causes explain things: material, formal, efficient, final</li>
+            <li>Forms exist within things, not in a separate realm</li>
+            <li>Virtue is a mean between extremes</li>
+            <li>Eudaimonia (flourishing) is the goal of human life</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mt-6">
+          <strong>Next up:</strong> In Module 5, we leap forward to the Medieval period, where 
+          philosophers grappled with the relationship between faith and reason.
+        </p>
+      </section>
+
+      <section id="section-4-7" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6">
+          Test your understanding of the concepts covered in this module.
+        </p>
+        <KnowledgeCheck
+          moduleId={4}
+          title="Module 4: Aristotle's Systematic Philosophy"
+          questions={module04Quiz}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module5Content.tsx
+++ b/src/tools/philosophy-intro/content/Module5Content.tsx
@@ -1,0 +1,172 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module05Quiz } from './quizzes';
+
+export function Module5Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-5-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          5.1 Philosophy in the Age of Faith
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          After the fall of Rome (476 CE), Europe entered a period where Christianity dominated 
+          intellectual life. Philosophy became intertwined with theology. The central question 
+          became: How do faith and reason relate?
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          During this period, much of Greek philosophy was preserved and transmitted through 
+          Islamic scholars, who translated Aristotle into Arabic and added their own commentaries.
+        </p>
+      </section>
+
+      <section id="section-5-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          5.2 Augustine of Hippo
+        </h2>
+
+        <PhilosopherCard
+          name="Augustine of Hippo"
+          years="354 - 430 CE"
+          location="North Africa (Roman Empire)"
+          school="Christian Platonism"
+          keyIdeas={['Original sin', 'Divine illumination', 'Free will', 'City of God']}
+          quote="Faith seeks understanding."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Augustine was one of the most influential Christian thinkers. Before his conversion, 
+          he explored various philosophies including Manichaeism and Neoplatonism. He eventually 
+          synthesized Platonic philosophy with Christian doctrine.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          For Augustine, Plato's Forms became ideas in the mind of God. The Form of the Good 
+          became God himself. Knowledge comes not from recollecting Forms but through divine 
+          illumination—God enlightening our minds.
+        </p>
+
+        <QuoteBlock
+          quote="You have made us for yourself, O Lord, and our hearts are restless until they rest in you."
+          author="Augustine"
+          source="Confessions"
+        />
+
+        <KeyTakeaway>
+          <p>
+            Augustine showed how ancient philosophy could be integrated with Christian belief, 
+            setting the pattern for medieval philosophy.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-5-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          5.3 Thomas Aquinas
+        </h2>
+
+        <PhilosopherCard
+          name="Thomas Aquinas"
+          years="1225 - 1274 CE"
+          location="Italy"
+          school="Scholasticism"
+          keyIdeas={['Five Ways', 'Natural law', 'Faith and reason harmony', 'Natural theology']}
+          quote="To one who has faith, no explanation is necessary. To one without faith, no explanation is possible."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Aquinas lived during the rediscovery of Aristotle's works in Western Europe. While 
+          Augustine drew on Plato, Aquinas synthesized Christian theology with Aristotelian 
+          philosophy.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Aquinas believed that faith and reason are complementary. Reason can prove certain 
+          truths about God (natural theology), while other truths require revelation.
+        </p>
+
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-white mb-3">
+          The Five Ways
+        </h3>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Aquinas offered five arguments for God's existence:
+        </p>
+
+        <ol className="list-decimal pl-6 space-y-3 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Motion:</strong> Things move, but nothing moves itself. There must be an unmoved mover.</li>
+          <li><strong>Causation:</strong> Every effect has a cause. There must be a first cause.</li>
+          <li><strong>Contingency:</strong> Things come into and go out of existence. Something must exist necessarily.</li>
+          <li><strong>Gradation:</strong> Things have degrees of perfection. There must be a most perfect being.</li>
+          <li><strong>Design:</strong> Nature shows order and purpose. There must be an intelligent designer.</li>
+        </ol>
+
+        <KeyTakeaway>
+          <p>
+            Aquinas argued that reason alone can lead us to God's existence, even without 
+            revelation. His synthesis of faith and reason became the official philosophy of 
+            the Catholic Church.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-5-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          5.4 Faith vs. Reason Debate
+        </h2>
+
+        <ComparisonTable
+          headers={['Position', 'View', 'Example']}
+          rows={[
+            ['Faith alone', 'Reason is irrelevant or harmful to faith', 'Tertullian'],
+            ['Reason supporting faith', 'Reason can prove some religious truths', 'Aquinas'],
+            ['Faith seeking understanding', 'Faith comes first, then seek to understand', 'Anselm, Augustine'],
+            ['Double truth', 'Faith and reason can reach different truths', 'Averroes (debated)'],
+          ]}
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          This debate continues today. Can religious beliefs be rationally justified? Do faith 
+          and science conflict? Medieval philosophers laid the groundwork for these discussions.
+        </p>
+      </section>
+
+      <section id="section-5-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Module Summary
+        </h2>
+
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Medieval philosophy merged classical philosophy with Christian theology</li>
+            <li>Augustine synthesized Christianity with Platonic ideas</li>
+            <li>Aquinas combined Aristotelian philosophy with Christian doctrine</li>
+            <li>The Five Ways attempt to prove God's existence through reason</li>
+            <li>The relationship between faith and reason was the central problem</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mt-6">
+          <strong>Next up:</strong> In Module 6, we enter the modern era with Descartes, who 
+          attempted to rebuild philosophy from the ground up.
+        </p>
+      </section>
+
+      <section id="section-5-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6">
+          Test your understanding of the concepts covered in this module.
+        </p>
+        <KnowledgeCheck
+          moduleId={5}
+          title="Module 5: Medieval Philosophy"
+          questions={module05Quiz}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module6Content.tsx
+++ b/src/tools/philosophy-intro/content/Module6Content.tsx
@@ -1,0 +1,166 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module06Quiz } from './quizzes';
+
+export function Module6Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-6-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          6.1 The Scientific Revolution
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          The 17th century saw a revolution in how humans understood nature. Copernicus, Galileo, 
+          and Newton showed that the universe operates according to mathematical laws, not 
+          Aristotelian purposes.
+        </p>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          This raised profound philosophical questions: If science reveals reality, what is 
+          the foundation of scientific knowledge? How can we be certain of anything?
+        </p>
+      </section>
+
+      <section id="section-6-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          6.2 Descartes' Method of Doubt
+        </h2>
+
+        <PhilosopherCard
+          name="Rene Descartes"
+          years="1596 - 1650"
+          location="France"
+          school="Rationalism"
+          keyIdeas={['Cogito ergo sum', 'Method of doubt', 'Mind-body dualism', 'Clear and distinct ideas']}
+          quote="I think, therefore I am."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Descartes wanted to find a foundation for knowledge that could not be doubted. His 
+          method: doubt everything that can possibly be doubted until you find something certain.
+        </p>
+
+        <DefinitionCard
+          term="Cartesian Doubt"
+          definition="A method of systematic skepticism: reject any belief that can be doubted in order to find what is absolutely certain."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          What can be doubted?
+        </p>
+
+        <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>The senses:</strong> They sometimes deceive us (optical illusions)</li>
+          <li><strong>The external world:</strong> We might be dreaming</li>
+          <li><strong>Mathematics:</strong> An evil demon might be deceiving us</li>
+        </ul>
+      </section>
+
+      <section id="section-6-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          6.3 Cogito Ergo Sum
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          After doubting everything, Descartes found one thing that cannot be doubted: the fact 
+          that he is thinking. Even if he is being deceived, there must be an "I" being deceived.
+        </p>
+
+        <QuoteBlock
+          quote="Cogito ergo sum — I think, therefore I am."
+          author="Descartes"
+          source="Meditations on First Philosophy"
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          This became the foundation for all knowledge. From this certain starting point, 
+          Descartes rebuilt philosophy:
+        </p>
+
+        <ol className="list-decimal pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li>I exist as a thinking thing</li>
+          <li>I have the idea of a perfect being (God)</li>
+          <li>This idea must come from a perfect being (therefore God exists)</li>
+          <li>A perfect God would not systematically deceive me</li>
+          <li>Therefore, my clear and distinct ideas are reliable</li>
+          <li>The external world exists</li>
+        </ol>
+
+        <KeyTakeaway>
+          <p>
+            Descartes established the "I" as the starting point for philosophy—the subject 
+            who thinks and knows. This turn to the subject defines modern philosophy.
+          </p>
+        </KeyTakeaway>
+      </section>
+
+      <section id="section-6-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          6.4 Rationalism vs. Empiricism
+        </h2>
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Descartes was a rationalist, believing that reason alone can give us knowledge of 
+          reality. He thought some ideas are innate—present in the mind from birth.
+        </p>
+
+        <ComparisonTable
+          headers={['Rationalism', 'Empiricism']}
+          rows={[
+            ['Reason is primary source of knowledge', 'Experience is primary source of knowledge'],
+            ['Some ideas are innate', 'Mind starts as a blank slate'],
+            ['Certainty comes from clear ideas', 'Certainty comes from observation'],
+            ['Descartes, Spinoza, Leibniz', 'Locke, Berkeley, Hume'],
+          ]}
+        />
+
+        <DefinitionCard
+          term="Mind-Body Problem"
+          definition="How can mind (a non-physical thinking substance) interact with body (a physical extended substance)? Descartes' dualism makes this interaction mysterious."
+        />
+
+        <p className="text-slate-700 dark:text-slate-300 mb-4">
+          Descartes' dualism—mind and body as two separate substances—raised a problem that 
+          philosophers still debate: How can something non-physical (mind) affect something 
+          physical (body)?
+        </p>
+      </section>
+
+      <section id="section-6-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Module Summary
+        </h2>
+
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Descartes used systematic doubt to find certain knowledge</li>
+            <li>"I think, therefore I am" is the indubitable starting point</li>
+            <li>Rationalism holds that reason, not experience, is primary</li>
+            <li>Mind-body dualism raises the problem of their interaction</li>
+            <li>Clear and distinct ideas provide the criterion for truth</li>
+          </ul>
+        </div>
+
+        <p className="text-slate-700 dark:text-slate-300 mt-6">
+          <strong>Next up:</strong> In Module 7, we meet the British Empiricists who challenged 
+          rationalism and argued that all knowledge comes from experience.
+        </p>
+      </section>
+
+      <section id="section-6-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+          Knowledge Check
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6">
+          Test your understanding of the concepts covered in this module.
+        </p>
+        <KnowledgeCheck
+          moduleId={6}
+          title="Module 6: The Dawn of Modern Philosophy"
+          questions={module06Quiz}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module7Content.tsx
+++ b/src/tools/philosophy-intro/content/Module7Content.tsx
@@ -1,0 +1,55 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module07Quiz } from './quizzes';
+
+export function Module7Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-7-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">7.1 Knowledge from Experience</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">The British empiricists challenged rationalism. They argued that there are no innate ideas—all knowledge comes from sensory experience.</p>
+        <DefinitionCard term="Empiricism" definition="The view that all knowledge derives from sensory experience. The mind at birth is a 'blank slate' written upon by experience." />
+      </section>
+
+      <section id="section-7-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">7.2 John Locke</h2>
+        <PhilosopherCard name="John Locke" years="1632 - 1704" location="England" school="Empiricism" keyIdeas={['Tabula rasa', 'Primary/secondary qualities', 'Natural rights', 'Social contract']} quote="No man's knowledge here can go beyond his experience." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Locke argued the mind at birth is a "tabula rasa" (blank slate). All ideas come from experience: either through sensation (external) or reflection (internal).</p>
+        <DefinitionCard term="Primary vs Secondary Qualities" definition="Primary qualities (size, shape, motion) exist in objects. Secondary qualities (color, taste, sound) exist only in our minds as responses to objects." />
+      </section>
+
+      <section id="section-7-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">7.3 George Berkeley</h2>
+        <PhilosopherCard name="George Berkeley" years="1685 - 1753" location="Ireland" school="Idealism" keyIdeas={['Esse est percipi', 'Immaterialism', 'Ideas as reality']} quote="To be is to be perceived." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Berkeley took empiricism to a radical conclusion: if we only know our perceptions, we have no reason to believe in matter at all. Reality consists only of minds and their ideas.</p>
+        <KeyTakeaway><p>For Berkeley, a tree falling in a forest with no one around doesn't make a sound—because without perception, nothing exists. But God's perception ensures the world's continuity.</p></KeyTakeaway>
+      </section>
+
+      <section id="section-7-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">7.4 David Hume</h2>
+        <PhilosopherCard name="David Hume" years="1711 - 1776" location="Scotland" school="Empiricism, Skepticism" keyIdeas={['Problem of induction', 'Causation as habit', 'Is-ought gap', 'Bundle theory of self']} quote="Reason is, and ought only to be the slave of the passions." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Hume was the most radical empiricist. He argued that causation is not something we observe but a habit of mind. We see one event follow another repeatedly, and we expect this pattern to continue—but we cannot prove it will.</p>
+        <DefinitionCard term="Problem of Induction" definition="We cannot rationally justify the assumption that the future will resemble the past. Yet all scientific prediction depends on this assumption." />
+        <QuoteBlock quote="When we run over libraries... what havoc must we make? If we take in our hand any volume... let us ask, Does it contain any abstract reasoning concerning quantity or number? No. Does it contain any experimental reasoning concerning matter of fact? No. Commit it then to the flames, for it can contain nothing but sophistry and illusion." author="Hume" source="An Enquiry Concerning Human Understanding" />
+      </section>
+
+      <section id="section-7-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Module Summary</h2>
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Empiricists reject innate ideas; all knowledge comes from experience</li>
+            <li>Locke: the mind is a blank slate</li>
+            <li>Berkeley: only minds and ideas exist</li>
+            <li>Hume: causation is habit; induction cannot be justified</li>
+          </ul>
+        </div>
+        <p className="text-slate-700 dark:text-slate-300 mt-6"><strong>Next up:</strong> In Module 8, Kant attempts to rescue knowledge from Hume's skepticism.</p>
+      </section>
+
+      <section id="section-7-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Knowledge Check</h2>
+        <KnowledgeCheck moduleId={7} title="Module 7: British Empiricism" questions={module07Quiz} />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module8Content.tsx
+++ b/src/tools/philosophy-intro/content/Module8Content.tsx
@@ -1,0 +1,62 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module08Quiz } from './quizzes';
+
+export function Module8Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-8-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">8.1 Awakened from Dogmatic Slumber</h2>
+        <PhilosopherCard name="Immanuel Kant" years="1724 - 1804" location="Konigsberg, Prussia" school="German Idealism" keyIdeas={['Critique of Pure Reason', 'Categorical imperative', 'Phenomena vs noumena', 'Synthetic a priori']} quote="Two things fill the mind with ever new and increasing admiration and awe: the starry heavens above me and the moral law within me." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Kant said that Hume's skepticism "awakened him from his dogmatic slumber." He set out to save both science and morality from skeptical attack.</p>
+      </section>
+
+      <section id="section-8-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">8.2 The Critique of Pure Reason</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Kant asked: How is knowledge possible? His answer revolutionized philosophy.</p>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Both rationalists and empiricists assumed the mind passively receives the world. Kant argued the mind actively structures experience. Space, time, and causation are not "out there" but are conditions the mind imposes on experience.</p>
+        <DefinitionCard term="Copernican Revolution in Philosophy" definition="Instead of knowledge conforming to objects, objects (as we experience them) conform to our cognitive faculties. We don't discover order in the world; we impose it." />
+        <ComparisonTable headers={['Concept', 'Meaning']} rows={[['Phenomena', 'Things as they appear to us, structured by our minds'], ['Noumena', 'Things in themselves, unknowable'], ['A priori', 'Knowledge independent of experience'], ['Synthetic a priori', 'Knowledge that is both informative and necessary']]} />
+        <KeyTakeaway><p>We can have certain knowledge of how things must appear to us, but we can never know things as they are in themselves. This limits but also secures our knowledge.</p></KeyTakeaway>
+      </section>
+
+      <section id="section-8-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">8.3 The Categorical Imperative</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">In ethics, Kant sought a universal moral principle grounded in reason alone. He called this the categorical imperative.</p>
+        <DefinitionCard term="Categorical Imperative" definition="Act only according to that maxim which you can at the same time will to be a universal law. In other words, ask: What if everyone did this?" />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Kant gave several formulations:</p>
+        <ol className="list-decimal pl-6 space-y-2 text-slate-700 dark:text-slate-300 mb-6">
+          <li><strong>Universal Law:</strong> Act only on maxims you could will to be universal laws</li>
+          <li><strong>Humanity:</strong> Treat humanity, in yourself and others, always as an end and never merely as a means</li>
+          <li><strong>Autonomy:</strong> Act as if you were a legislator in a kingdom of ends</li>
+        </ol>
+        <QuoteBlock quote="Act in such a way that you treat humanity, whether in your own person or in the person of any other, never merely as a means to an end, but always at the same time as an end." author="Kant" source="Groundwork of the Metaphysics of Morals" />
+      </section>
+
+      <section id="section-8-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">8.4 Kant's Legacy</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Kant's philosophy transformed every area of thought. His ethics of duty influenced human rights discourse. His epistemology shaped debates about science and knowledge. His aesthetics influenced art criticism.</p>
+        <KeyTakeaway><p>After Kant, philosophy could no longer ignore the role of the knowing subject. How we experience the world depends partly on what we bring to experience.</p></KeyTakeaway>
+      </section>
+
+      <section id="section-8-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Module Summary</h2>
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Kant synthesized rationalism and empiricism</li>
+            <li>The mind actively structures experience</li>
+            <li>We know phenomena (appearances) but not noumena (things in themselves)</li>
+            <li>The categorical imperative provides a universal moral test</li>
+            <li>Treat people as ends, never merely as means</li>
+          </ul>
+        </div>
+        <p className="text-slate-700 dark:text-slate-300 mt-6"><strong>Next up:</strong> In Module 9, we explore the 19th century reactions to Kant from Hegel, Marx, and Nietzsche.</p>
+      </section>
+
+      <section id="section-8-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Knowledge Check</h2>
+        <KnowledgeCheck moduleId={8} title="Module 8: Kant's Revolution" questions={module08Quiz} />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/Module9Content.tsx
+++ b/src/tools/philosophy-intro/content/Module9Content.tsx
@@ -1,0 +1,63 @@
+import { DefinitionCard, KeyTakeaway, PhilosopherCard, QuoteBlock, ComparisonTable } from '../components/content';
+import { KnowledgeCheck } from '../components/interactive/assessments';
+import { module09Quiz } from './quizzes';
+
+export function Module9Content() {
+  return (
+    <div className="space-y-8">
+      <section id="section-9-1">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">9.1 German Idealism</h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">The 19th century saw dramatic philosophical developments. German idealists tried to complete Kant's project, while others challenged the entire tradition.</p>
+      </section>
+
+      <section id="section-9-2" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">9.2 Hegel's Dialectic</h2>
+        <PhilosopherCard name="G.W.F. Hegel" years="1770 - 1831" location="Germany" school="Absolute Idealism" keyIdeas={['Dialectic', 'Absolute Spirit', 'History as progress', 'Master-slave dialectic']} quote="The owl of Minerva spreads its wings only with the falling of dusk." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Hegel saw history as the development of Spirit (Geist) toward self-understanding. This happens through a dialectical process:</p>
+        <DefinitionCard term="Hegelian Dialectic" definition="A process where a thesis generates its antithesis (opposition), and the tension is resolved in a synthesis that transcends both while preserving what was true in each." />
+        <div className="bg-slate-100 dark:bg-slate-800 rounded-xl p-6 my-6">
+          <p className="text-slate-700 dark:text-slate-300"><strong>Thesis:</strong> An initial position or idea</p>
+          <p className="text-slate-700 dark:text-slate-300"><strong>Antithesis:</strong> The opposite or negation of the thesis</p>
+          <p className="text-slate-700 dark:text-slate-300"><strong>Synthesis:</strong> A higher unity that reconciles both</p>
+        </div>
+        <p className="text-slate-700 dark:text-slate-300 mb-4">For Hegel, this process operates in thought, history, and reality itself. History is progress toward freedom and rationality.</p>
+      </section>
+
+      <section id="section-9-3" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">9.3 Marx and Historical Materialism</h2>
+        <PhilosopherCard name="Karl Marx" years="1818 - 1883" location="Germany/England" school="Marxism" keyIdeas={['Historical materialism', 'Class struggle', 'Alienation', 'Critique of capitalism']} quote="The philosophers have only interpreted the world; the point is to change it." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Marx "turned Hegel on his head." While Hegel saw ideas driving history, Marx argued that material economic conditions are fundamental.</p>
+        <DefinitionCard term="Historical Materialism" definition="The theory that economic conditions (modes of production) form the base that shapes social structures, politics, and ideas (the superstructure)." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Marx analyzed capitalism as a system of exploitation where workers are alienated from their labor, products, fellow workers, and human nature itself. He predicted capitalism would give way to communism through class struggle.</p>
+        <QuoteBlock quote="Workers of the world, unite! You have nothing to lose but your chains." author="Marx and Engels" source="The Communist Manifesto" />
+      </section>
+
+      <section id="section-9-4" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">9.4 Nietzsche's Transvaluation</h2>
+        <PhilosopherCard name="Friedrich Nietzsche" years="1844 - 1900" location="Germany" school="Existentialism precursor" keyIdeas={['Will to power', 'Ubermensch', 'Eternal recurrence', 'Master/slave morality']} quote="God is dead. God remains dead. And we have killed him." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Nietzsche proclaimed the "death of God"—not a theological claim but a cultural observation. Traditional values, based on religion, have lost their power. We must create new values.</p>
+        <DefinitionCard term="Will to Power" definition="The fundamental drive of life, not toward survival or pleasure, but toward growth, expansion, and self-overcoming." />
+        <p className="text-slate-700 dark:text-slate-300 mb-4">Nietzsche criticized traditional morality as "slave morality"—a morality of the weak designed to restrain the strong. He called for a "transvaluation of all values" and the emergence of the Ubermensch (overman) who creates their own values.</p>
+        <KeyTakeaway><p>Nietzsche challenges us to examine where our values come from. Are they life-affirming or life-denying? Do they express strength or weakness?</p></KeyTakeaway>
+      </section>
+
+      <section id="section-9-5" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Module Summary</h2>
+        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <ul className="list-disc pl-6 space-y-2 text-slate-700 dark:text-slate-300">
+            <li>Hegel: History is Spirit's development through dialectic</li>
+            <li>Marx: Material conditions, not ideas, drive history</li>
+            <li>Nietzsche: God is dead; we must create new values</li>
+            <li>All three influenced 20th century thought profoundly</li>
+          </ul>
+        </div>
+        <p className="text-slate-700 dark:text-slate-300 mt-6"><strong>Next up:</strong> In Module 10, we explore existentialism and its response to these challenges.</p>
+      </section>
+
+      <section id="section-9-6" className="pt-8 border-t border-slate-200 dark:border-slate-700">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Knowledge Check</h2>
+        <KnowledgeCheck moduleId={9} title="Module 9: 19th Century Philosophy" questions={module09Quiz} />
+      </section>
+    </div>
+  );
+}

--- a/src/tools/philosophy-intro/content/quizzes/index.ts
+++ b/src/tools/philosophy-intro/content/quizzes/index.ts
@@ -1,0 +1,12 @@
+export { module01Quiz } from './module-01-quiz';
+export { module02Quiz } from './module-02-quiz';
+export { module03Quiz } from './module-03-quiz';
+export { module04Quiz } from './module-04-quiz';
+export { module05Quiz } from './module-05-quiz';
+export { module06Quiz } from './module-06-quiz';
+export { module07Quiz } from './module-07-quiz';
+export { module08Quiz } from './module-08-quiz';
+export { module09Quiz } from './module-09-quiz';
+export { module10Quiz } from './module-10-quiz';
+export { module11Quiz } from './module-11-quiz';
+export { module12Quiz } from './module-12-quiz';

--- a/src/tools/philosophy-intro/content/quizzes/module-01-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-01-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module01Quiz: QuizQuestion[] = [
+  {
+    id: 'm1-q1',
+    type: 'multiple-choice',
+    question: 'What does the word "philosophy" literally mean in Greek?',
+    options: [
+      'Study of nature',
+      'Love of wisdom',
+      'Search for truth',
+      'Way of life',
+    ],
+    correctAnswer: 1,
+    explanation: 'Philosophy comes from the Greek words "philos" (love) and "sophia" (wisdom), meaning "love of wisdom."',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm1-q2',
+    type: 'multiple-choice',
+    question: 'Which philosopher is credited with being the first to seek natural explanations for phenomena?',
+    options: [
+      'Socrates',
+      'Plato',
+      'Thales of Miletus',
+      'Aristotle',
+    ],
+    correctAnswer: 2,
+    explanation: 'Thales of Miletus (c. 624-546 BCE) is considered the first philosopher because he sought natural rather than mythological explanations for the world.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm1-q3',
+    type: 'multiple-choice',
+    question: 'What was Heraclitus famous for saying about the nature of reality?',
+    options: [
+      'Everything is made of atoms',
+      'Everything is one',
+      'Everything flows (panta rhei)',
+      'Everything is illusion',
+    ],
+    correctAnswer: 2,
+    explanation: 'Heraclitus believed that change is the fundamental nature of reality, famously stating "panta rhei" (everything flows) and that you cannot step into the same river twice.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm1-q4',
+    type: 'multiple-choice',
+    question: 'Parmenides argued that change is:',
+    options: [
+      'The most fundamental aspect of reality',
+      'An illusion because reality is unchanging',
+      'Caused by the gods',
+      'Only possible in the physical world',
+    ],
+    correctAnswer: 1,
+    explanation: 'Parmenides argued that change is impossible and illusory, and that "What Is" must be eternal, unchanging, and one.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm1-q5',
+    type: 'multiple-choice',
+    question: 'What major shift did the Pre-Socratic philosophers represent?',
+    options: [
+      'From polytheism to monotheism',
+      'From mythological to rational explanation',
+      'From oral to written tradition',
+      'From Eastern to Western thought',
+    ],
+    correctAnswer: 1,
+    explanation: 'The Pre-Socratics marked a crucial shift from explaining the world through myths and gods to seeking rational, natural explanations for phenomena.',
+    difficulty: 'easy',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-02-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-02-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module02Quiz: QuizQuestion[] = [
+  {
+    id: 'm2-q1',
+    type: 'multiple-choice',
+    question: 'What is the Socratic method primarily characterized by?',
+    options: [
+      'Giving long lectures on philosophy',
+      'Asking probing questions to examine beliefs',
+      'Writing detailed philosophical texts',
+      'Conducting scientific experiments',
+    ],
+    correctAnswer: 1,
+    explanation: 'The Socratic method involves asking a series of questions to stimulate critical thinking and expose contradictions in one\'s beliefs.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm2-q2',
+    type: 'multiple-choice',
+    question: 'What did Socrates mean by "I know that I know nothing"?',
+    options: [
+      'He was uneducated',
+      'True wisdom begins with recognizing our ignorance',
+      'Knowledge is impossible to attain',
+      'He was being modest',
+    ],
+    correctAnswer: 1,
+    explanation: 'Socrates believed that recognizing the limits of one\'s knowledge is the beginning of wisdom. He was wiser than others because he knew he didn\'t know.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm2-q3',
+    type: 'multiple-choice',
+    question: 'Socrates was charged with which of the following crimes?',
+    options: [
+      'Theft and fraud',
+      'Corrupting the youth and impiety',
+      'Treason against Athens',
+      'Practicing medicine without a license',
+    ],
+    correctAnswer: 1,
+    explanation: 'Socrates was charged with corrupting the youth of Athens and not believing in the gods of the city (impiety).',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm2-q4',
+    type: 'multiple-choice',
+    question: 'According to Socrates, how is virtue related to knowledge?',
+    options: [
+      'They are unrelated',
+      'Virtue is knowledge; no one does wrong knowingly',
+      'Knowledge prevents virtue',
+      'Virtue comes from faith, not knowledge',
+    ],
+    correctAnswer: 1,
+    explanation: 'Socrates believed that virtue is a form of knowledge. If someone truly knows what is good, they will do it. Wrongdoing is a result of ignorance.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm2-q5',
+    type: 'multiple-choice',
+    question: 'Why did Socrates accept his death sentence rather than escape?',
+    options: [
+      'He was too old to run',
+      'He believed in obeying the laws of Athens',
+      'His friends refused to help him',
+      'He wanted to become a martyr',
+    ],
+    correctAnswer: 1,
+    explanation: 'Socrates believed that as a citizen who benefited from Athens\' laws, he had an obligation to accept their judgment, even if unjust.',
+    difficulty: 'medium',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-03-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-03-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module03Quiz: QuizQuestion[] = [
+  {
+    id: 'm3-q1',
+    type: 'multiple-choice',
+    question: 'According to Plato\'s Theory of Forms, what are Forms?',
+    options: [
+      'Physical objects in the world',
+      'Perfect, eternal, unchanging templates of things',
+      'Human inventions and concepts',
+      'Religious symbols',
+    ],
+    correctAnswer: 1,
+    explanation: 'Forms are perfect, eternal, and unchanging templates or essences that exist in a realm beyond the physical world. Physical objects are imperfect copies of these Forms.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm3-q2',
+    type: 'multiple-choice',
+    question: 'In the Allegory of the Cave, what do the shadows on the wall represent?',
+    options: [
+      'The Forms',
+      'The physical world as we perceive it',
+      'True knowledge',
+      'The soul',
+    ],
+    correctAnswer: 1,
+    explanation: 'The shadows represent our ordinary perception of the physical world, which is only an imperfect reflection of true reality (the Forms).',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm3-q3',
+    type: 'multiple-choice',
+    question: 'What does the sun represent in the Allegory of the Cave?',
+    options: [
+      'Physical light',
+      'The Form of the Good',
+      'The visible world',
+      'Religious faith',
+    ],
+    correctAnswer: 1,
+    explanation: 'The sun represents the Form of the Good, the highest Form that illuminates all other Forms and makes knowledge possible.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm3-q4',
+    type: 'multiple-choice',
+    question: 'In Plato\'s Republic, who should rule the ideal state?',
+    options: [
+      'The wealthy',
+      'The military',
+      'Philosopher-kings',
+      'The common people',
+    ],
+    correctAnswer: 2,
+    explanation: 'Plato believed that philosopher-kings should rule because only those who understand the Forms, especially the Form of the Good, can govern justly.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm3-q5',
+    type: 'multiple-choice',
+    question: 'How did Plato distinguish between knowledge and opinion?',
+    options: [
+      'Knowledge is about the physical world; opinion is about the Forms',
+      'Knowledge is about Forms; opinion is about the changing physical world',
+      'There is no difference between them',
+      'Knowledge comes from the senses; opinion from reason',
+    ],
+    correctAnswer: 1,
+    explanation: 'Plato believed that true knowledge (episteme) is only possible of the eternal Forms, while opinion (doxa) is what we have about the changing physical world.',
+    difficulty: 'medium',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-04-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-04-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module04Quiz: QuizQuestion[] = [
+  {
+    id: 'm4-q1',
+    type: 'multiple-choice',
+    question: 'How did Aristotle\'s view of universals differ from Plato\'s?',
+    options: [
+      'Aristotle denied that universals exist',
+      'Aristotle believed universals exist in particular things, not a separate realm',
+      'Aristotle agreed completely with Plato',
+      'Aristotle believed only universals exist',
+    ],
+    correctAnswer: 1,
+    explanation: 'Unlike Plato, Aristotle believed that universals (forms) exist within particular things themselves, not in a separate realm of Forms.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm4-q2',
+    type: 'multiple-choice',
+    question: 'What are Aristotle\'s four causes?',
+    options: [
+      'Earth, water, fire, air',
+      'Material, formal, efficient, final',
+      'Physical, mental, spiritual, divine',
+      'Past, present, future, eternal',
+    ],
+    correctAnswer: 1,
+    explanation: 'Aristotle\'s four causes explain why something exists: material (what it\'s made of), formal (its shape/essence), efficient (what made it), and final (its purpose).',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm4-q3',
+    type: 'multiple-choice',
+    question: 'According to Aristotle\'s virtue ethics, virtue is:',
+    options: [
+      'Following divine commands',
+      'A mean between extremes',
+      'Always doing what makes you happy',
+      'Obeying the law',
+    ],
+    correctAnswer: 1,
+    explanation: 'Aristotle taught that virtue is a "golden mean" between two extremes. For example, courage is the mean between cowardice and recklessness.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm4-q4',
+    type: 'multiple-choice',
+    question: 'What did Aristotle consider the highest human good (eudaimonia)?',
+    options: [
+      'Wealth',
+      'Pleasure',
+      'Flourishing through virtuous activity',
+      'Fame',
+    ],
+    correctAnswer: 2,
+    explanation: 'Eudaimonia (often translated as happiness or flourishing) is achieved through living virtuously and realizing one\'s full potential as a rational being.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm4-q5',
+    type: 'multiple-choice',
+    question: 'Aristotle developed the system of logic based on:',
+    options: [
+      'Mathematical proofs',
+      'Syllogisms',
+      'Empirical observation only',
+      'Divine revelation',
+    ],
+    correctAnswer: 1,
+    explanation: 'Aristotle created formal logic based on syllogisms, which are arguments with two premises and a conclusion (e.g., All men are mortal; Socrates is a man; therefore Socrates is mortal).',
+    difficulty: 'easy',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-05-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-05-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module05Quiz: QuizQuestion[] = [
+  {
+    id: 'm5-q1',
+    type: 'multiple-choice',
+    question: 'How did Augustine synthesize Christian thought with Greek philosophy?',
+    options: [
+      'He rejected all Greek philosophy',
+      'He combined Christian theology with Platonic ideas',
+      'He combined Christian theology with Aristotelian ideas',
+      'He kept them completely separate',
+    ],
+    correctAnswer: 1,
+    explanation: 'Augustine merged Christian doctrine with Platonic philosophy, particularly the idea of eternal truths existing in a higher realm (which he identified with the mind of God).',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm5-q2',
+    type: 'multiple-choice',
+    question: 'What is the central problem that medieval philosophers grappled with?',
+    options: [
+      'The nature of matter',
+      'The relationship between faith and reason',
+      'The existence of other minds',
+      'The problem of induction',
+    ],
+    correctAnswer: 1,
+    explanation: 'Medieval philosophers were primarily concerned with how to reconcile religious faith with philosophical reasoning and whether they could coexist.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm5-q3',
+    type: 'multiple-choice',
+    question: 'What are Thomas Aquinas\'s Five Ways?',
+    options: [
+      'Five methods of meditation',
+      'Five arguments for God\'s existence',
+      'Five types of sin',
+      'Five paths to salvation',
+    ],
+    correctAnswer: 1,
+    explanation: 'The Five Ways are five arguments Aquinas presented to prove God\'s existence, including the argument from motion, causation, necessity, gradation, and design.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm5-q4',
+    type: 'multiple-choice',
+    question: 'Unlike Augustine, Aquinas drew heavily on which philosopher?',
+    options: [
+      'Plato',
+      'Aristotle',
+      'Heraclitus',
+      'Epicurus',
+    ],
+    correctAnswer: 1,
+    explanation: 'Aquinas synthesized Christian theology with Aristotelian philosophy, particularly Aristotle\'s metaphysics and ethics.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm5-q5',
+    type: 'multiple-choice',
+    question: 'What role did Islamic philosophers play in medieval Western philosophy?',
+    options: [
+      'They had no influence',
+      'They preserved and transmitted Greek philosophy to the West',
+      'They only influenced religious thought',
+      'They rejected Greek philosophy entirely',
+    ],
+    correctAnswer: 1,
+    explanation: 'Islamic philosophers like Avicenna and Averroes preserved, translated, and commented on Greek philosophical texts, transmitting them to medieval Europe.',
+    difficulty: 'medium',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-06-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-06-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module06Quiz: QuizQuestion[] = [
+  {
+    id: 'm6-q1',
+    type: 'multiple-choice',
+    question: 'What was Descartes\' method of doubt designed to achieve?',
+    options: [
+      'To prove nothing can be known',
+      'To find a foundation of certain knowledge',
+      'To criticize the Church',
+      'To support scientific theories',
+    ],
+    correctAnswer: 1,
+    explanation: 'Descartes used systematic doubt to strip away all uncertain beliefs and find something absolutely certain that could serve as a foundation for knowledge.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm6-q2',
+    type: 'multiple-choice',
+    question: 'What does "Cogito ergo sum" mean?',
+    options: [
+      'Knowledge is power',
+      'I think, therefore I am',
+      'God exists',
+      'The world is real',
+    ],
+    correctAnswer: 1,
+    explanation: '"Cogito ergo sum" means "I think, therefore I am." Descartes concluded that even if deceived about everything, the fact that he thinks proves he exists.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm6-q3',
+    type: 'multiple-choice',
+    question: 'What is the mind-body problem that Descartes\' philosophy raises?',
+    options: [
+      'Whether the body can exist without food',
+      'How mental and physical substances interact',
+      'Whether the mind can read other minds',
+      'How to keep the body healthy',
+    ],
+    correctAnswer: 1,
+    explanation: 'Descartes\' dualism (mind and body as separate substances) raises the question of how two fundamentally different things can interact with each other.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm6-q4',
+    type: 'multiple-choice',
+    question: 'Rationalists believe that knowledge primarily comes from:',
+    options: [
+      'Sensory experience',
+      'Reason and innate ideas',
+      'Divine revelation',
+      'Experimentation',
+    ],
+    correctAnswer: 1,
+    explanation: 'Rationalists like Descartes believed that the most important knowledge comes from reason and that some ideas are innate (present from birth).',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm6-q5',
+    type: 'multiple-choice',
+    question: 'The evil demon hypothesis in Descartes\' Meditations suggests:',
+    options: [
+      'Demons are real',
+      'We cannot trust our senses or reasoning because we might be deceived',
+      'God is actually evil',
+      'Science is unreliable',
+    ],
+    correctAnswer: 1,
+    explanation: 'The evil demon is a thought experiment: even if a powerful deceiver tricks us about everything, we can still be certain we exist (as thinking things).',
+    difficulty: 'medium',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-07-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-07-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module07Quiz: QuizQuestion[] = [
+  {
+    id: 'm7-q1',
+    type: 'multiple-choice',
+    question: 'What is Locke\'s "tabula rasa" theory?',
+    options: [
+      'The mind has innate ideas',
+      'The mind starts as a blank slate, filled by experience',
+      'Reality is an illusion',
+      'Knowledge is impossible',
+    ],
+    correctAnswer: 1,
+    explanation: 'Locke argued that the mind at birth is a "tabula rasa" (blank slate), and all our ideas come from sensory experience.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm7-q2',
+    type: 'multiple-choice',
+    question: 'Berkeley\'s idealism claims that:',
+    options: [
+      'Ideas are the only reality; material objects exist only as perceptions',
+      'Reality is completely material',
+      'Both mind and matter exist independently',
+      'We can never know anything',
+    ],
+    correctAnswer: 0,
+    explanation: 'Berkeley argued "to be is to be perceived" - physical objects have no existence independent of being perceived by minds.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm7-q3',
+    type: 'multiple-choice',
+    question: 'What did Hume argue about causation?',
+    options: [
+      'Causation is proven by science',
+      'We never observe causation, only constant conjunction of events',
+      'Everything has a cause',
+      'Causation is created by God',
+    ],
+    correctAnswer: 1,
+    explanation: 'Hume argued we never actually perceive causation itself, only that one event regularly follows another (constant conjunction). Causation is a habit of mind.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm7-q4',
+    type: 'multiple-choice',
+    question: 'Empiricists generally reject the idea of:',
+    options: [
+      'Sensory experience',
+      'Innate ideas',
+      'Scientific method',
+      'Logic',
+    ],
+    correctAnswer: 1,
+    explanation: 'Empiricists argue against innate ideas (ideas we are born with), claiming all knowledge derives from sensory experience.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm7-q5',
+    type: 'multiple-choice',
+    question: 'Hume\'s problem of induction questions whether:',
+    options: [
+      'Deductive reasoning is valid',
+      'We can justify believing the future will resemble the past',
+      'Mathematical truths are certain',
+      'Morality is objective',
+    ],
+    correctAnswer: 1,
+    explanation: 'Hume pointed out that we cannot rationally justify our belief that the future will be like the past (the basis of all scientific prediction).',
+    difficulty: 'hard',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-08-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-08-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module08Quiz: QuizQuestion[] = [
+  {
+    id: 'm8-q1',
+    type: 'multiple-choice',
+    question: 'Kant said that Hume\'s skepticism did what to him?',
+    options: [
+      'Put him to sleep',
+      'Awakened him from dogmatic slumber',
+      'Made him abandon philosophy',
+      'Proved him right',
+    ],
+    correctAnswer: 1,
+    explanation: 'Kant famously said that reading Hume "awakened him from his dogmatic slumber" and led him to develop his critical philosophy.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm8-q2',
+    type: 'multiple-choice',
+    question: 'What is the categorical imperative?',
+    options: [
+      'A scientific law',
+      'A universal moral principle based on duty',
+      'A suggestion for good behavior',
+      'A religious commandment',
+    ],
+    correctAnswer: 1,
+    explanation: 'The categorical imperative is Kant\'s supreme moral principle: act only according to rules you could will to be universal laws.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm8-q3',
+    type: 'multiple-choice',
+    question: 'According to Kant, what are phenomena?',
+    options: [
+      'Things as they are in themselves',
+      'Things as they appear to us',
+      'Illusions',
+      'Pure concepts',
+    ],
+    correctAnswer: 1,
+    explanation: 'Phenomena are things as they appear to us, shaped by our cognitive faculties. We cannot know things-in-themselves (noumena).',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm8-q4',
+    type: 'multiple-choice',
+    question: 'How did Kant try to resolve the rationalism vs. empiricism debate?',
+    options: [
+      'He rejected both completely',
+      'He sided with the rationalists',
+      'He argued that both reason and experience are necessary for knowledge',
+      'He proved empiricism correct',
+    ],
+    correctAnswer: 2,
+    explanation: 'Kant argued that while knowledge begins with experience, the mind actively structures that experience through innate categories and concepts.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm8-q5',
+    type: 'multiple-choice',
+    question: 'What does it mean to treat someone as an "end in themselves"?',
+    options: [
+      'To use them for your purposes',
+      'To respect their inherent dignity and rational agency',
+      'To ignore them',
+      'To put them last',
+    ],
+    correctAnswer: 1,
+    explanation: 'Kant\'s second formulation of the categorical imperative says we must treat humanity, in ourselves and others, always as an end and never merely as a means.',
+    difficulty: 'easy',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-09-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-09-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module09Quiz: QuizQuestion[] = [
+  {
+    id: 'm9-q1',
+    type: 'multiple-choice',
+    question: 'What is Hegel\'s dialectical method?',
+    options: [
+      'A form of meditation',
+      'Thesis, antithesis, synthesis',
+      'Scientific experimentation',
+      'Religious contemplation',
+    ],
+    correctAnswer: 1,
+    explanation: 'Hegel\'s dialectic involves a thesis (idea) generating its antithesis (opposite), and the tension resolving in a synthesis that transcends both.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm9-q2',
+    type: 'multiple-choice',
+    question: 'Marx\'s historical materialism argues that:',
+    options: [
+      'Ideas drive history',
+      'Economic conditions and class struggle drive history',
+      'Great individuals drive history',
+      'History has no pattern',
+    ],
+    correctAnswer: 1,
+    explanation: 'Marx believed that material economic conditions and the conflict between classes are the primary forces shaping history and society.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm9-q3',
+    type: 'multiple-choice',
+    question: 'What did Nietzsche mean by "God is dead"?',
+    options: [
+      'A literal claim about a deity',
+      'Traditional values and religious foundations have lost their power',
+      'Science has disproved religion',
+      'Atheism is the only rational position',
+    ],
+    correctAnswer: 1,
+    explanation: 'Nietzsche meant that belief in God and traditional moral values had lost their hold on Western culture, requiring a revaluation of all values.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm9-q4',
+    type: 'multiple-choice',
+    question: 'What is the Ubermensch (overman) in Nietzsche\'s philosophy?',
+    options: [
+      'A superhero',
+      'A person who creates their own values and overcomes conventional morality',
+      'A perfect human being',
+      'God',
+    ],
+    correctAnswer: 1,
+    explanation: 'The Ubermensch represents someone who can create new values after the collapse of traditional ones, affirming life and their own will.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm9-q5',
+    type: 'multiple-choice',
+    question: 'According to Marx, what is alienation?',
+    options: [
+      'Being lonely',
+      'Workers being disconnected from their work, products, and humanity',
+      'Mental illness',
+      'Being a foreigner',
+    ],
+    correctAnswer: 1,
+    explanation: 'Marx argued that capitalism alienates workers from their labor, the products they make, their fellow workers, and their human potential.',
+    difficulty: 'medium',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-10-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-10-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module10Quiz: QuizQuestion[] = [
+  {
+    id: 'm10-q1',
+    type: 'multiple-choice',
+    question: 'What does "existence precedes essence" mean?',
+    options: [
+      'We have a fixed nature from birth',
+      'We exist first, then create our own meaning and identity through choices',
+      'God determines our purpose',
+      'Essence is more important than existence',
+    ],
+    correctAnswer: 1,
+    explanation: 'Sartre\'s famous phrase means we are not born with a predetermined purpose; we exist first and then define ourselves through our free choices.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm10-q2',
+    type: 'multiple-choice',
+    question: 'What did Kierkegaard mean by the "leap of faith"?',
+    options: [
+      'Blind belief in anything',
+      'A commitment to religious belief that goes beyond rational proof',
+      'Physical jumping',
+      'Scientific hypothesis',
+    ],
+    correctAnswer: 1,
+    explanation: 'Kierkegaard argued that religious faith requires a personal, subjective commitment that cannot be fully justified by reason alone.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm10-q3',
+    type: 'multiple-choice',
+    question: 'According to Sartre, humans are "condemned to be free." This means:',
+    options: [
+      'Freedom is a punishment',
+      'We cannot escape responsibility for our choices',
+      'We have too much freedom',
+      'Freedom is an illusion',
+    ],
+    correctAnswer: 1,
+    explanation: 'Sartre means we have no choice but to choose; we cannot escape freedom and the responsibility that comes with it.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm10-q4',
+    type: 'multiple-choice',
+    question: 'Camus argued that the fundamental philosophical question is:',
+    options: [
+      'What is the meaning of life?',
+      'Whether life is worth living (the question of suicide)',
+      'Does God exist?',
+      'What is truth?',
+    ],
+    correctAnswer: 1,
+    explanation: 'In The Myth of Sisyphus, Camus states that judging whether life is worth living is the only truly serious philosophical problem.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm10-q5',
+    type: 'multiple-choice',
+    question: 'Existentialists generally believe that:',
+    options: [
+      'Human nature is fixed and determined',
+      'Individuals must create their own meaning in an indifferent universe',
+      'Science can answer all philosophical questions',
+      'Traditional values are sufficient for a good life',
+    ],
+    correctAnswer: 1,
+    explanation: 'Existentialists emphasize individual freedom, choice, and the necessity of creating meaning in a world without inherent purpose.',
+    difficulty: 'easy',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-11-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-11-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module11Quiz: QuizQuestion[] = [
+  {
+    id: 'm11-q1',
+    type: 'multiple-choice',
+    question: 'What characterizes the "linguistic turn" in philosophy?',
+    options: [
+      'Studying foreign languages',
+      'Focusing on language analysis as central to philosophical problems',
+      'Writing in simpler language',
+      'Translating ancient texts',
+    ],
+    correctAnswer: 1,
+    explanation: 'The linguistic turn involved viewing many philosophical problems as rooted in misunderstandings of language, making language analysis central to philosophy.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm11-q2',
+    type: 'multiple-choice',
+    question: 'Logical positivists claimed that meaningful statements must be:',
+    options: [
+      'True',
+      'Either analytically true or empirically verifiable',
+      'Approved by scientists',
+      'Written in formal logic',
+    ],
+    correctAnswer: 1,
+    explanation: 'The verification principle held that a statement is meaningful only if it is either analytically true (true by definition) or can be verified by experience.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm11-q3',
+    type: 'multiple-choice',
+    question: 'In his later work, Wittgenstein argued that:',
+    options: [
+      'Language has one perfect logical form',
+      'Meaning comes from use in various "language games"',
+      'Philosophy should become science',
+      'Words have fixed meanings',
+    ],
+    correctAnswer: 1,
+    explanation: 'Later Wittgenstein argued that meaning is determined by use in context (language games), rejecting his earlier view of language as having a single logical structure.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm11-q4',
+    type: 'multiple-choice',
+    question: 'What distinguishes analytic philosophy from continental philosophy?',
+    options: [
+      'Geographic location only',
+      'Analytic focuses on clarity, logic, and language; continental on history, culture, existence',
+      'They study completely different topics',
+      'There is no real difference',
+    ],
+    correctAnswer: 1,
+    explanation: 'Analytic philosophy emphasizes logical analysis, clear argumentation, and language, while continental philosophy tends toward historical, existential, and phenomenological approaches.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm11-q5',
+    type: 'multiple-choice',
+    question: 'Bertrand Russell\'s theory of descriptions addressed:',
+    options: [
+      'How to describe emotions',
+      'How to analyze statements about things that don\'t exist',
+      'Literary techniques',
+      'Scientific method',
+    ],
+    correctAnswer: 1,
+    explanation: 'Russell\'s theory showed how to analyze sentences like "The present King of France is bald" without committing to the existence of non-existent things.',
+    difficulty: 'hard',
+  },
+];

--- a/src/tools/philosophy-intro/content/quizzes/module-12-quiz.ts
+++ b/src/tools/philosophy-intro/content/quizzes/module-12-quiz.ts
@@ -1,0 +1,74 @@
+import type { QuizQuestion } from '../../types';
+
+export const module12Quiz: QuizQuestion[] = [
+  {
+    id: 'm12-q1',
+    type: 'multiple-choice',
+    question: 'What is the "hard problem of consciousness"?',
+    options: [
+      'How the brain processes information',
+      'Why there is subjective experience at all',
+      'How to measure consciousness',
+      'Whether animals are conscious',
+    ],
+    correctAnswer: 1,
+    explanation: 'The hard problem asks why physical processes in the brain give rise to subjective experience - why there is "something it is like" to be conscious.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm12-q2',
+    type: 'multiple-choice',
+    question: 'Utilitarianism judges actions based on:',
+    options: [
+      'Intentions',
+      'Consequences - maximizing happiness for the greatest number',
+      'Following rules',
+      'Character traits',
+    ],
+    correctAnswer: 1,
+    explanation: 'Utilitarianism, developed by Bentham and Mill, judges actions solely by their consequences: the right action maximizes overall happiness.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm12-q3',
+    type: 'multiple-choice',
+    question: 'John Rawls\' "veil of ignorance" is used to:',
+    options: [
+      'Hide information from voters',
+      'Determine principles of justice without knowing your position in society',
+      'Test intelligence',
+      'Create mystery in philosophy',
+    ],
+    correctAnswer: 1,
+    explanation: 'Rawls asks us to imagine choosing principles of justice without knowing our race, gender, wealth, or abilities, to ensure fairness.',
+    difficulty: 'medium',
+  },
+  {
+    id: 'm12-q4',
+    type: 'multiple-choice',
+    question: 'What is effective altruism?',
+    options: [
+      'Being kind to everyone',
+      'Using evidence and reason to determine the most effective ways to help others',
+      'Donating money anonymously',
+      'Volunteering locally',
+    ],
+    correctAnswer: 1,
+    explanation: 'Effective altruism uses evidence and reasoning to determine how to benefit others as much as possible, often focusing on neglected global problems.',
+    difficulty: 'easy',
+  },
+  {
+    id: 'm12-q5',
+    type: 'multiple-choice',
+    question: 'The philosophy of mind debates whether:',
+    options: [
+      'Thinking is good or bad',
+      'Mental states can be reduced to or explained by physical states',
+      'Education improves thinking',
+      'Animals can think',
+    ],
+    correctAnswer: 1,
+    explanation: 'A central question in philosophy of mind is the mind-body problem: how mental states relate to physical brain states.',
+    difficulty: 'medium',
+  },
+];

--- a/src/tools/philosophy-intro/store/index.ts
+++ b/src/tools/philosophy-intro/store/index.ts
@@ -1,0 +1,1 @@
+export { useProgressStore } from './useProgressStore';

--- a/src/tools/philosophy-intro/store/useProgressStore.ts
+++ b/src/tools/philosophy-intro/store/useProgressStore.ts
@@ -1,0 +1,121 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { UserProgress, ModuleProgress } from '../types';
+import { DEFAULT_PROGRESS } from '../types/user';
+
+interface ProgressState {
+  progress: UserProgress;
+  setCurrentModule: (moduleId: number) => void;
+  completeModule: (moduleId: number) => void;
+  updateModuleProgress: (moduleId: number, sectionId: string) => void;
+  completeQuiz: (moduleId: number, score: number) => void;
+  addTimeSpent: (seconds: number) => void;
+  resetProgress: () => void;
+}
+
+export const useProgressStore = create<ProgressState>()(
+  persist(
+    (set) => ({
+      progress: DEFAULT_PROGRESS,
+
+      setCurrentModule: (moduleId: number) => {
+        set((state) => ({
+          progress: {
+            ...state.progress,
+            currentModule: moduleId,
+            lastVisited: new Date().toISOString(),
+          },
+        }));
+      },
+
+      completeModule: (moduleId: number) => {
+        set((state) => {
+          const completedModules = state.progress.completedModules.includes(moduleId)
+            ? state.progress.completedModules
+            : [...state.progress.completedModules, moduleId];
+          return {
+            progress: {
+              ...state.progress,
+              completedModules,
+            },
+          };
+        });
+      },
+
+      updateModuleProgress: (moduleId: number, sectionId: string) => {
+        set((state) => {
+          const existing: ModuleProgress = state.progress.moduleProgress[moduleId] || {
+            moduleId,
+            sectionsCompleted: [],
+            quizCompleted: false,
+            quizScore: null,
+            timeSpent: 0,
+            lastAccessed: new Date().toISOString(),
+          };
+
+          const sectionsCompleted = existing.sectionsCompleted.includes(sectionId)
+            ? existing.sectionsCompleted
+            : [...existing.sectionsCompleted, sectionId];
+
+          return {
+            progress: {
+              ...state.progress,
+              moduleProgress: {
+                ...state.progress.moduleProgress,
+                [moduleId]: {
+                  ...existing,
+                  sectionsCompleted,
+                  lastAccessed: new Date().toISOString(),
+                },
+              },
+            },
+          };
+        });
+      },
+
+      completeQuiz: (moduleId: number, score: number) => {
+        set((state) => {
+          const existing: ModuleProgress = state.progress.moduleProgress[moduleId] || {
+            moduleId,
+            sectionsCompleted: [],
+            quizCompleted: false,
+            quizScore: null,
+            timeSpent: 0,
+            lastAccessed: new Date().toISOString(),
+          };
+
+          return {
+            progress: {
+              ...state.progress,
+              moduleProgress: {
+                ...state.progress.moduleProgress,
+                [moduleId]: {
+                  ...existing,
+                  quizCompleted: true,
+                  quizScore: score,
+                  lastAccessed: new Date().toISOString(),
+                },
+              },
+            },
+          };
+        });
+      },
+
+      addTimeSpent: (seconds: number) => {
+        set((state) => ({
+          progress: {
+            ...state.progress,
+            totalTimeSpent: state.progress.totalTimeSpent + seconds,
+          },
+        }));
+      },
+
+      resetProgress: () => {
+        set({ progress: DEFAULT_PROGRESS });
+      },
+    }),
+    {
+      name: 'philosophy-intro:progress',
+    }
+  )
+);

--- a/src/tools/philosophy-intro/types/index.ts
+++ b/src/tools/philosophy-intro/types/index.ts
@@ -1,0 +1,4 @@
+export * from './module';
+export * from './quiz';
+export * from './user';
+export * from './philosopher';

--- a/src/tools/philosophy-intro/types/module.ts
+++ b/src/tools/philosophy-intro/types/module.ts
@@ -1,0 +1,312 @@
+export interface Module {
+  id: number;
+  title: string;
+  shortTitle: string;
+  part: number;
+  partTitle: string;
+  description: string;
+  estimatedTime: number;
+  objectives: string[];
+  sections: ModuleSection[];
+}
+
+export interface ModuleSection {
+  id: string;
+  title: string;
+  type: 'content' | 'interactive' | 'quiz' | 'resources';
+}
+
+export interface ModuleProgress {
+  moduleId: number;
+  sectionsCompleted: string[];
+  quizCompleted: boolean;
+  quizScore: number | null;
+  timeSpent: number;
+  lastAccessed: string;
+}
+
+export const MODULES: Module[] = [
+  {
+    id: 1,
+    title: 'The Birth of Philosophy',
+    shortTitle: 'Origins',
+    part: 1,
+    partTitle: 'Ancient Philosophy',
+    description: 'Discover how philosophy emerged in ancient Greece and the questions that started it all.',
+    estimatedTime: 40,
+    objectives: [
+      'Explain what philosophy is and why it emerged in ancient Greece',
+      'Identify the Pre-Socratic philosophers and their key questions',
+      'Understand the shift from mythological to rational explanation',
+      'Recognize the enduring relevance of ancient questions',
+    ],
+    sections: [
+      { id: '1.1', title: 'What is Philosophy?', type: 'content' },
+      { id: '1.2', title: 'Why Ancient Greece?', type: 'content' },
+      { id: '1.3', title: 'The Pre-Socratics', type: 'content' },
+      { id: '1.4', title: 'Timeline Explorer', type: 'interactive' },
+      { id: '1.5', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 2,
+    title: 'Socrates and the Socratic Method',
+    shortTitle: 'Socrates',
+    part: 1,
+    partTitle: 'Ancient Philosophy',
+    description: 'Meet the philosopher who changed everything by asking questions.',
+    estimatedTime: 45,
+    objectives: [
+      'Describe Socrates\' life and historical significance',
+      'Explain the Socratic method of questioning',
+      'Apply Socratic questioning to examine beliefs',
+      'Understand why Socrates was sentenced to death',
+    ],
+    sections: [
+      { id: '2.1', title: 'The Life of Socrates', type: 'content' },
+      { id: '2.2', title: '"I Know That I Know Nothing"', type: 'content' },
+      { id: '2.3', title: 'The Socratic Method', type: 'content' },
+      { id: '2.4', title: 'Socratic Dialogue Simulator', type: 'interactive' },
+      { id: '2.5', title: 'The Trial and Death of Socrates', type: 'content' },
+      { id: '2.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 3,
+    title: 'Plato\'s World of Forms',
+    shortTitle: 'Plato',
+    part: 1,
+    partTitle: 'Ancient Philosophy',
+    description: 'Explore the theory that changed how we think about reality.',
+    estimatedTime: 50,
+    objectives: [
+      'Explain Plato\'s Theory of Forms',
+      'Interpret the Allegory of the Cave',
+      'Understand Plato\'s view of knowledge vs. opinion',
+      'Describe Plato\'s ideal state in the Republic',
+    ],
+    sections: [
+      { id: '3.1', title: 'From Student to Founder', type: 'content' },
+      { id: '3.2', title: 'The Theory of Forms', type: 'content' },
+      { id: '3.3', title: 'The Allegory of the Cave', type: 'content' },
+      { id: '3.4', title: 'Cave Allegory Visualizer', type: 'interactive' },
+      { id: '3.5', title: 'Plato\'s Republic', type: 'content' },
+      { id: '3.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 4,
+    title: 'Aristotle\'s Systematic Philosophy',
+    shortTitle: 'Aristotle',
+    part: 1,
+    partTitle: 'Ancient Philosophy',
+    description: 'The student who challenged his teacher and built a system of everything.',
+    estimatedTime: 50,
+    objectives: [
+      'Contrast Aristotle\'s approach with Plato\'s',
+      'Explain Aristotle\'s four causes',
+      'Understand virtue ethics and the golden mean',
+      'Recognize Aristotle\'s influence on Western thought',
+    ],
+    sections: [
+      { id: '4.1', title: 'The Student Who Disagreed', type: 'content' },
+      { id: '4.2', title: 'Logic and Categories', type: 'content' },
+      { id: '4.3', title: 'The Four Causes', type: 'content' },
+      { id: '4.4', title: 'Virtue Ethics', type: 'content' },
+      { id: '4.5', title: 'Philosopher Comparison Tool', type: 'interactive' },
+      { id: '4.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 5,
+    title: 'Medieval Philosophy',
+    shortTitle: 'Medieval',
+    part: 2,
+    partTitle: 'Medieval & Early Modern Philosophy',
+    description: 'How faith and reason wrestled for a thousand years.',
+    estimatedTime: 45,
+    objectives: [
+      'Understand the role of religion in medieval philosophy',
+      'Explain Augustine\'s synthesis of Christianity and Platonism',
+      'Describe Aquinas\'s Five Ways to prove God\'s existence',
+      'Recognize the tension between faith and reason',
+    ],
+    sections: [
+      { id: '5.1', title: 'Philosophy in the Age of Faith', type: 'content' },
+      { id: '5.2', title: 'Augustine of Hippo', type: 'content' },
+      { id: '5.3', title: 'Thomas Aquinas', type: 'content' },
+      { id: '5.4', title: 'Faith vs. Reason Debate', type: 'content' },
+      { id: '5.5', title: 'Arguments Analyzer', type: 'interactive' },
+      { id: '5.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 6,
+    title: 'The Dawn of Modern Philosophy',
+    shortTitle: 'Descartes',
+    part: 2,
+    partTitle: 'Medieval & Early Modern Philosophy',
+    description: 'Descartes doubts everything and rebuilds knowledge from the ground up.',
+    estimatedTime: 50,
+    objectives: [
+      'Explain Descartes\' method of doubt',
+      'Understand "I think, therefore I am"',
+      'Contrast rationalism and empiricism',
+      'Identify the mind-body problem',
+    ],
+    sections: [
+      { id: '6.1', title: 'The Scientific Revolution', type: 'content' },
+      { id: '6.2', title: 'Descartes\' Method of Doubt', type: 'content' },
+      { id: '6.3', title: 'Cogito Ergo Sum', type: 'content' },
+      { id: '6.4', title: 'Rationalism vs. Empiricism', type: 'content' },
+      { id: '6.5', title: 'Thought Experiment Lab', type: 'interactive' },
+      { id: '6.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 7,
+    title: 'British Empiricism',
+    shortTitle: 'Empiricism',
+    part: 2,
+    partTitle: 'Medieval & Early Modern Philosophy',
+    description: 'Locke, Berkeley, and Hume argue that all knowledge comes from experience.',
+    estimatedTime: 45,
+    objectives: [
+      'Explain Locke\'s tabula rasa theory',
+      'Understand Berkeley\'s idealism',
+      'Describe Hume\'s skepticism about causation',
+      'Trace the empiricist critique of innate ideas',
+    ],
+    sections: [
+      { id: '7.1', title: 'Knowledge from Experience', type: 'content' },
+      { id: '7.2', title: 'John Locke', type: 'content' },
+      { id: '7.3', title: 'George Berkeley', type: 'content' },
+      { id: '7.4', title: 'David Hume', type: 'content' },
+      { id: '7.5', title: 'Epistemology Comparison', type: 'interactive' },
+      { id: '7.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 8,
+    title: 'Kant\'s Revolution',
+    shortTitle: 'Kant',
+    part: 3,
+    partTitle: 'Enlightenment to 19th Century',
+    description: 'How one philosopher tried to save both reason and experience.',
+    estimatedTime: 55,
+    objectives: [
+      'Explain how Kant synthesized rationalism and empiricism',
+      'Understand the categorical imperative',
+      'Describe phenomena vs. noumena',
+      'Recognize Kant\'s influence on modern ethics',
+    ],
+    sections: [
+      { id: '8.1', title: 'Awakened from Dogmatic Slumber', type: 'content' },
+      { id: '8.2', title: 'The Critique of Pure Reason', type: 'content' },
+      { id: '8.3', title: 'The Categorical Imperative', type: 'content' },
+      { id: '8.4', title: 'Ethics Decision Analyzer', type: 'interactive' },
+      { id: '8.5', title: 'Kant\'s Legacy', type: 'content' },
+      { id: '8.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 9,
+    title: '19th Century Philosophy',
+    shortTitle: '19th Century',
+    part: 3,
+    partTitle: 'Enlightenment to 19th Century',
+    description: 'Hegel, Marx, and Nietzsche shake the foundations.',
+    estimatedTime: 50,
+    objectives: [
+      'Explain Hegel\'s dialectic',
+      'Understand Nietzsche\'s critique of morality',
+      'Describe Marx\'s historical materialism',
+      'Recognize the rise of existential themes',
+    ],
+    sections: [
+      { id: '9.1', title: 'German Idealism', type: 'content' },
+      { id: '9.2', title: 'Hegel\'s Dialectic', type: 'content' },
+      { id: '9.3', title: 'Marx and Historical Materialism', type: 'content' },
+      { id: '9.4', title: 'Nietzsche\'s Transvaluation', type: 'content' },
+      { id: '9.5', title: 'Dialectic Visualizer', type: 'interactive' },
+      { id: '9.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 10,
+    title: 'Existentialism',
+    shortTitle: 'Existentialism',
+    part: 4,
+    partTitle: '20th Century to Present',
+    description: 'What does it mean to exist? The existentialists grapple with freedom and meaning.',
+    estimatedTime: 50,
+    objectives: [
+      'Define existentialism and its key themes',
+      'Explain Kierkegaard\'s leap of faith',
+      'Understand Sartre\'s "existence precedes essence"',
+      'Apply existentialist concepts to personal meaning',
+    ],
+    sections: [
+      { id: '10.1', title: 'Existence Precedes Essence', type: 'content' },
+      { id: '10.2', title: 'Kierkegaard: Father of Existentialism', type: 'content' },
+      { id: '10.3', title: 'Sartre and Radical Freedom', type: 'content' },
+      { id: '10.4', title: 'Camus and the Absurd', type: 'content' },
+      { id: '10.5', title: 'Meaning Finder Exercise', type: 'interactive' },
+      { id: '10.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 11,
+    title: 'Analytic Philosophy',
+    shortTitle: 'Analytic',
+    part: 4,
+    partTitle: '20th Century to Present',
+    description: 'The linguistic turn and the pursuit of clarity.',
+    estimatedTime: 45,
+    objectives: [
+      'Distinguish analytic from continental philosophy',
+      'Explain the linguistic turn',
+      'Understand logical positivism',
+      'Recognize Wittgenstein\'s influence',
+    ],
+    sections: [
+      { id: '11.1', title: 'The Analytic Tradition', type: 'content' },
+      { id: '11.2', title: 'Russell and Early Analytic Philosophy', type: 'content' },
+      { id: '11.3', title: 'Wittgenstein\'s Two Philosophies', type: 'content' },
+      { id: '11.4', title: 'Logical Positivism', type: 'content' },
+      { id: '11.5', title: 'Language Analysis Tool', type: 'interactive' },
+      { id: '11.6', title: 'Knowledge Check', type: 'quiz' },
+    ],
+  },
+  {
+    id: 12,
+    title: 'Contemporary Philosophy',
+    shortTitle: 'Contemporary',
+    part: 4,
+    partTitle: '20th Century to Present',
+    description: 'Where philosophy stands today and where it might go.',
+    estimatedTime: 50,
+    objectives: [
+      'Survey major contemporary movements',
+      'Understand ethics in the modern world',
+      'Explore philosophy of mind debates',
+      'Apply philosophical thinking to current issues',
+    ],
+    sections: [
+      { id: '12.1', title: 'Philosophy Today', type: 'content' },
+      { id: '12.2', title: 'Ethics: Utilitarianism to Effective Altruism', type: 'content' },
+      { id: '12.3', title: 'Philosophy of Mind', type: 'content' },
+      { id: '12.4', title: 'Political Philosophy', type: 'content' },
+      { id: '12.5', title: 'Full Timeline Explorer', type: 'interactive' },
+      { id: '12.6', title: 'Final Assessment', type: 'quiz' },
+      { id: '12.7', title: 'Where to Go Next', type: 'resources' },
+    ],
+  },
+];
+
+export const PARTS = [
+  { id: 1, title: 'Ancient Philosophy', modules: [1, 2, 3, 4] },
+  { id: 2, title: 'Medieval & Early Modern Philosophy', modules: [5, 6, 7] },
+  { id: 3, title: 'Enlightenment to 19th Century', modules: [8, 9] },
+  { id: 4, title: '20th Century to Present', modules: [10, 11, 12] },
+];

--- a/src/tools/philosophy-intro/types/philosopher.ts
+++ b/src/tools/philosophy-intro/types/philosopher.ts
@@ -1,0 +1,71 @@
+export type PhilosophicalEra = 
+  | 'ancient' 
+  | 'medieval' 
+  | 'early-modern' 
+  | 'enlightenment'
+  | 'modern' 
+  | 'contemporary';
+
+export type PhilosophicalSchool =
+  | 'pre-socratic'
+  | 'socratic'
+  | 'platonism'
+  | 'aristotelianism'
+  | 'stoicism'
+  | 'epicureanism'
+  | 'skepticism'
+  | 'neoplatonism'
+  | 'scholasticism'
+  | 'rationalism'
+  | 'empiricism'
+  | 'idealism'
+  | 'materialism'
+  | 'existentialism'
+  | 'phenomenology'
+  | 'analytic'
+  | 'pragmatism'
+  | 'postmodernism';
+
+export interface Philosopher {
+  id: string;
+  name: string;
+  birthYear: number;
+  deathYear: number | null;
+  era: PhilosophicalEra;
+  schools: PhilosophicalSchool[];
+  keyIdeas: string[];
+  influences: string[];
+  influenced: string[];
+  quote: string;
+  nationality: string;
+}
+
+export interface ThoughtExperiment {
+  id: string;
+  name: string;
+  philosopher: string;
+  era: PhilosophicalEra;
+  description: string;
+  steps: string[];
+  questions: string[];
+  relatedConcepts: string[];
+}
+
+export interface EthicalFramework {
+  id: string;
+  name: string;
+  proponent: string;
+  principle: string;
+  howToApply: string[];
+  strengths: string[];
+  weaknesses: string[];
+}
+
+export interface PhilosophicalConcept {
+  id: string;
+  name: string;
+  definition: string;
+  relatedPhilosophers: string[];
+  era: PhilosophicalEra;
+  category: 'metaphysics' | 'epistemology' | 'ethics' | 'logic' | 'aesthetics' | 'political';
+}

--- a/src/tools/philosophy-intro/types/quiz.ts
+++ b/src/tools/philosophy-intro/types/quiz.ts
@@ -1,0 +1,30 @@
+export interface QuizQuestion {
+  id: string;
+  type: 'multiple-choice' | 'true-false' | 'fill-blank';
+  question: string;
+  options?: string[];
+  correctAnswer: string | number;
+  explanation: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  relatedConcept?: string;
+}
+
+export interface QuizResult {
+  score: number;
+  totalQuestions: number;
+  answers: QuizAnswer[];
+  completedAt: string;
+  timeSpent: number;
+}
+
+export interface QuizAnswer {
+  questionId: string;
+  selectedAnswer: string | number;
+  correct: boolean;
+}
+
+export interface Quiz {
+  moduleId: number;
+  title: string;
+  questions: QuizQuestion[];
+}

--- a/src/tools/philosophy-intro/types/user.ts
+++ b/src/tools/philosophy-intro/types/user.ts
@@ -1,0 +1,33 @@
+import type { ModuleProgress } from './module';
+
+export interface UserProgress {
+  currentModule: number;
+  completedModules: number[];
+  moduleProgress: Record<number, ModuleProgress>;
+  totalTimeSpent: number;
+  lastVisited: string;
+  streak: number;
+  longestStreak: number;
+}
+
+export interface UserPreferences {
+  darkMode: boolean;
+  animationsEnabled: boolean;
+  showHints: boolean;
+}
+
+export const DEFAULT_PROGRESS: UserProgress = {
+  currentModule: 1,
+  completedModules: [],
+  moduleProgress: {},
+  totalTimeSpent: 0,
+  lastVisited: new Date().toISOString(),
+  streak: 0,
+  longestStreak: 0,
+};
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  darkMode: false,
+  animationsEnabled: true,
+  showHints: true,
+};


### PR DESCRIPTION
## Summary

Add a comprehensive **Introduction to Philosophy History** interactive learning platform, accessible at `/tools/philosophy-intro`.

## Features

### Curriculum (12 Modules)
- **Part I: Ancient Philosophy** - Pre-Socratics, Socrates, Plato, Aristotle
- **Part II: Medieval & Early Modern** - Augustine, Aquinas, Descartes, British Empiricists
- **Part III: Enlightenment to 19th Century** - Kant, Hegel, Marx, Nietzsche
- **Part IV: 20th Century to Present** - Existentialism, Analytic Philosophy, Contemporary

### Interactive Components
- Knowledge Check quizzes for each module (60 questions total)
- Progress tracking with localStorage persistence
- Lazy-loaded module content for performance
- Responsive design with mobile sidebar navigation

### Framework & Documentation
- Created abstract framework for building interactive learning tools
- Added study-playground-generator droid for generating future learning platforms

## Technical Details
- Follows the same architecture as the existing Accounting Fundamentals platform
- Uses Zustand for state management with localStorage persistence
- All modules lazy-loaded for optimal bundle size
- Build passes, all 90 tests pass