### PR TITLE
feat: add Agent Engineering Lab MVP

### DIFF
--- a/src/components/agent-lab/AgentLabApp.tsx
+++ b/src/components/agent-lab/AgentLabApp.tsx
@@ -1,0 +1,59 @@
+import { useMemo, useState } from 'react';
+import { scenarios } from '../../data/agent-lab/scenarios';
+import { runScenario } from '../../lib/agent-lab/agentRunner';
+import type { Scenario, TraceEvent } from '../../lib/agent-lab/types';
+import ApprovalGate from './ApprovalGate';
+import ToolCallPanel from './ToolCallPanel';
+import TraceTimeline from './TraceTimeline';
+
+export default function AgentLabApp() {
+  const [selectedScenarioId, setSelectedScenarioId] = useState(scenarios[0].id);
+  const [trace, setTrace] = useState<TraceEvent[]>([]);
+  const [finalAnswer, setFinalAnswer] = useState('');
+  const [needsApproval, setNeedsApproval] = useState(false);
+
+  const selectedScenario = useMemo(
+    () => scenarios.find((scenario: Scenario) => scenario.id === selectedScenarioId) ?? scenarios[0],
+    [selectedScenarioId],
+  );
+
+  const run = async (approval = false) => {
+    const result = await runScenario(selectedScenario, approval);
+    setTrace(result.trace);
+    setFinalAnswer(result.finalAnswer);
+    setNeedsApproval(result.requiresApproval);
+  };
+
+  const latestToolCall = [...trace].reverse().find(event => event.type === 'tool_call');
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-2">
+      <div className="space-y-4">
+        <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Agent Engineering Lab</h1>
+        <p className="text-slate-600 dark:text-slate-300">Inspect each step of an agent workflow: tools, policy, approvals, and final recommendation.</p>
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Scenario</label>
+        <select value={selectedScenarioId} onChange={event => setSelectedScenarioId(event.target.value)} className="w-full p-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800">
+          {scenarios.map(scenario => (
+            <option key={scenario.id} value={scenario.id}>{scenario.title}</option>
+          ))}
+        </select>
+        <button type="button" onClick={() => run(false)} className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors">Run simulation</button>
+        <ApprovalGate visible={needsApproval} onApprove={() => run(true)} onReject={() => setNeedsApproval(false)} />
+        <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+          <h2 className="font-semibold mb-2">Final answer</h2>
+          <p className="text-sm text-slate-700 dark:text-slate-300">{finalAnswer || 'Run a scenario to produce an answer.'}</p>
+        </div>
+      </div>
+      <div className="space-y-4">
+        <div>
+          <h2 className="font-semibold mb-2">Trace timeline</h2>
+          <TraceTimeline trace={trace} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Latest tool call payload</h2>
+          <ToolCallPanel event={latestToolCall} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/agent-lab/ApprovalGate.tsx
+++ b/src/components/agent-lab/ApprovalGate.tsx
@@ -1,0 +1,25 @@
+type Props = {
+  visible: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+};
+
+export default function ApprovalGate({ visible, onApprove, onReject }: Props) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="border border-blue-200 dark:border-blue-700 rounded-lg p-4 bg-blue-50 dark:bg-blue-950/30">
+      <p className="font-medium text-slate-900 dark:text-slate-100 mb-3">Approval required before write action.</p>
+      <div className="flex gap-2">
+        <button type="button" onClick={onApprove} className="px-3 py-2 rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors">
+          Approve
+        </button>
+        <button type="button" onClick={onReject} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 hover:border-blue-400 transition-colors">
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent-lab/ToolCallPanel.tsx
+++ b/src/components/agent-lab/ToolCallPanel.tsx
@@ -1,0 +1,15 @@
+import type { TraceEvent } from '../../lib/agent-lab/types';
+
+type Props = { event?: TraceEvent };
+
+export default function ToolCallPanel({ event }: Props) {
+  if (!event) {
+    return <p className="text-sm text-slate-500 dark:text-slate-400">Run a scenario to inspect tool calls.</p>;
+  }
+
+  return (
+    <pre className="text-xs overflow-x-auto p-3 rounded-lg bg-slate-100 dark:bg-slate-950 border border-slate-200 dark:border-slate-700">
+      {JSON.stringify(event.payload, null, 2)}
+    </pre>
+  );
+}

--- a/src/components/agent-lab/TraceTimeline.tsx
+++ b/src/components/agent-lab/TraceTimeline.tsx
@@ -1,0 +1,16 @@
+import type { TraceEvent } from '../../lib/agent-lab/types';
+
+type Props = { trace: TraceEvent[] };
+
+export default function TraceTimeline({ trace }: Props) {
+  return (
+    <ol className="space-y-3">
+      {trace.map(event => (
+        <li key={event.id} className="border border-slate-200 dark:border-slate-700 rounded-lg p-3 bg-white dark:bg-slate-900">
+          <p className="font-medium text-slate-900 dark:text-slate-100">{event.title}</p>
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{event.type}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/data/agent-lab/customers.ts
+++ b/src/data/agent-lab/customers.ts
@@ -1,0 +1,31 @@
+import type { Customer } from '../../lib/agent-lab/types';
+
+export const customers: Customer[] = [
+  {
+    id: 'cust_acme',
+    name: 'ACME Corp',
+    creditLimit: 50000,
+    currentExposure: 38000,
+    paymentTerms: 'Net 30',
+    riskLevel: 'medium',
+    accountStatus: 'watchlist',
+  },
+  {
+    id: 'cust_globex',
+    name: 'Globex',
+    creditLimit: 100000,
+    currentExposure: 22000,
+    paymentTerms: 'Net 45',
+    riskLevel: 'low',
+    accountStatus: 'active',
+  },
+  {
+    id: 'cust_initech',
+    name: 'Initech',
+    creditLimit: 30000,
+    currentExposure: 28000,
+    paymentTerms: 'Net 15',
+    riskLevel: 'high',
+    accountStatus: 'blocked',
+  },
+];

--- a/src/data/agent-lab/invoices.ts
+++ b/src/data/agent-lab/invoices.ts
@@ -1,0 +1,8 @@
+import type { Invoice } from '../../lib/agent-lab/types';
+
+export const invoices: Invoice[] = [
+  { id: 'inv_1001', customerId: 'cust_acme', amount: 12000, dueDate: '2026-03-21', status: 'overdue', daysPastDue: 42 },
+  { id: 'inv_1002', customerId: 'cust_acme', amount: 8000, dueDate: '2026-04-20', status: 'open', daysPastDue: 0 },
+  { id: 'inv_2001', customerId: 'cust_globex', amount: 5000, dueDate: '2026-04-28', status: 'open', daysPastDue: 0 },
+  { id: 'inv_3001', customerId: 'cust_initech', amount: 10000, dueDate: '2026-02-10', status: 'overdue', daysPastDue: 80 },
+];

--- a/src/data/agent-lab/scenarios.ts
+++ b/src/data/agent-lab/scenarios.ts
@@ -1,0 +1,25 @@
+import type { Scenario } from '../../lib/agent-lab/types';
+
+export const scenarios: Scenario[] = [
+  {
+    id: 'scn_acme_20k',
+    title: 'ACME credit order eligibility',
+    customerName: 'ACME',
+    orderAmount: 20000,
+    userPrompt: 'Can customer ACME place a new order for $20,000?',
+  },
+  {
+    id: 'scn_globex_5k',
+    title: 'Globex small order',
+    customerName: 'Globex',
+    orderAmount: 5000,
+    userPrompt: 'Can Globex place a new order for $5,000?',
+  },
+  {
+    id: 'scn_initech_4k',
+    title: 'Initech blocked account',
+    customerName: 'Initech',
+    orderAmount: 4000,
+    userPrompt: 'Can Initech place a new order for $4,000?',
+  },
+];

--- a/src/lib/agent-lab/agentRunner.test.ts
+++ b/src/lib/agent-lab/agentRunner.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { scenarios } from '../../data/agent-lab/scenarios';
+import { runScenario } from './agentRunner';
+
+describe('runScenario', () => {
+  it('ACME 20k triggers approval requirement', async () => {
+    const result = await runScenario(scenarios[0]);
+    expect(result.requiresApproval).toBe(true);
+    expect(result.finalAnswer).toContain('should not be auto-approved');
+  });
+
+  it('Globex 5k is approved', async () => {
+    const result = await runScenario(scenarios[1]);
+    expect(result.requiresApproval).toBe(false);
+    expect(result.finalAnswer).toContain('can be auto-approved');
+  });
+
+  it('Initech is blocked', async () => {
+    const result = await runScenario(scenarios[2]);
+    expect(result.finalAnswer).toContain('blocked');
+  });
+});

--- a/src/lib/agent-lab/agentRunner.ts
+++ b/src/lib/agent-lab/agentRunner.ts
@@ -1,0 +1,70 @@
+import { evaluateToolPermission } from './policy';
+import { createCreditReviewTicket, getCreditStatus, getCustomer, getOpenInvoices } from './mockTools';
+import type { RunResult, Scenario, TraceEvent } from './types';
+
+const createEvent = (event: Omit<TraceEvent, 'id' | 'timestamp'>): TraceEvent => ({
+  ...event,
+  id: crypto.randomUUID(),
+  timestamp: Date.now(),
+});
+
+export async function runScenario(scenario: Scenario, approvalGranted = false): Promise<RunResult> {
+  const trace: TraceEvent[] = [];
+  trace.push(createEvent({ type: 'user_message', title: 'User request', payload: scenario.userPrompt }));
+
+  const customer = await getCustomer(scenario.customerName);
+  if (!customer) {
+    const finalAnswer = `Customer ${scenario.customerName} was not found.`;
+    trace.push(createEvent({ type: 'error', title: 'Customer lookup failed', payload: scenario.customerName }));
+    trace.push(createEvent({ type: 'final_answer', title: 'Final answer', payload: finalAnswer }));
+    return { trace, finalAnswer, requiresApproval: false };
+  }
+
+  trace.push(createEvent({ type: 'tool_call', title: 'Tool call: getCustomer', payload: { customerNameOrId: scenario.customerName } }));
+  trace.push(createEvent({ type: 'tool_result', title: 'Tool result: getCustomer', payload: customer }));
+
+  const credit = await getCreditStatus(customer.id);
+  trace.push(createEvent({ type: 'tool_call', title: 'Tool call: getCreditStatus', payload: { customerId: customer.id } }));
+  trace.push(createEvent({ type: 'tool_result', title: 'Tool result: getCreditStatus', payload: credit }));
+
+  const openInvoices = await getOpenInvoices(customer.id);
+  trace.push(createEvent({ type: 'tool_call', title: 'Tool call: getOpenInvoices', payload: { customerId: customer.id } }));
+  trace.push(createEvent({ type: 'tool_result', title: 'Tool result: getOpenInvoices', payload: openInvoices }));
+
+  const projectedExposure = credit.currentExposure + scenario.orderAmount;
+  const overdueCount = openInvoices.filter(invoice => invoice.daysPastDue > 0).length;
+  const overLimit = projectedExposure - credit.creditLimit;
+
+  if (customer.accountStatus === 'blocked') {
+    const finalAnswer = `${customer.name} is blocked. Order cannot be approved.`;
+    trace.push(createEvent({ type: 'final_answer', title: 'Final answer', payload: finalAnswer }));
+    return { trace, finalAnswer, requiresApproval: false };
+  }
+
+  if (overLimit > 0 || overdueCount > 0 || customer.riskLevel !== 'low') {
+    const permission = evaluateToolPermission('createCreditReviewTicket', { customerId: customer.id });
+    trace.push(createEvent({ type: 'permission_check', title: 'Permission check', payload: permission }));
+
+    if (permission.decision === 'requires_approval' && !approvalGranted) {
+      const finalAnswer = `${customer.name} should not be auto-approved. Human approval is required before creating a credit review ticket.`;
+      trace.push(createEvent({ type: 'approval_required', title: 'Approval required', payload: { tool: 'createCreditReviewTicket', reason: permission.reason } }));
+      trace.push(createEvent({ type: 'final_answer', title: 'Final answer', payload: finalAnswer }));
+      return { trace, finalAnswer, requiresApproval: true };
+    }
+
+    const ticket = await createCreditReviewTicket(
+      customer.id,
+      `Projected exposure is ${projectedExposure} with ${overdueCount} overdue invoices.`,
+    );
+    trace.push(createEvent({ type: 'tool_call', title: 'Tool call: createCreditReviewTicket', payload: { customerId: customer.id } }));
+    trace.push(createEvent({ type: 'tool_result', title: 'Tool result: createCreditReviewTicket', payload: ticket }));
+
+    const finalAnswer = `${customer.name} should not be auto-approved for $${scenario.orderAmount.toLocaleString()}. Credit review ticket ${ticket.ticketId} created.`;
+    trace.push(createEvent({ type: 'final_answer', title: 'Final answer', payload: finalAnswer }));
+    return { trace, finalAnswer, requiresApproval: false };
+  }
+
+  const finalAnswer = `${customer.name} can be auto-approved for $${scenario.orderAmount.toLocaleString()}.`;
+  trace.push(createEvent({ type: 'final_answer', title: 'Final answer', payload: finalAnswer }));
+  return { trace, finalAnswer, requiresApproval: false };
+}

--- a/src/lib/agent-lab/mockTools.test.ts
+++ b/src/lib/agent-lab/mockTools.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getCreditStatus, getCustomer, getOpenInvoices } from './mockTools';
+
+describe('mockTools', () => {
+  it('finds ACME by name token', async () => {
+    const customer = await getCustomer('ACME');
+    expect(customer?.name).toBe('ACME Corp');
+  });
+
+  it('returns credit status with available credit', async () => {
+    const customer = await getCustomer('Globex');
+    if (!customer) throw new Error('Missing customer fixture');
+    const credit = await getCreditStatus(customer.id);
+    expect(credit.availableCredit).toBe(78000);
+  });
+
+  it('returns open invoices for a customer', async () => {
+    const customer = await getCustomer('Initech');
+    if (!customer) throw new Error('Missing customer fixture');
+    const openInvoices = await getOpenInvoices(customer.id);
+    expect(openInvoices.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/agent-lab/mockTools.ts
+++ b/src/lib/agent-lab/mockTools.ts
@@ -1,0 +1,44 @@
+import { customers } from '../../data/agent-lab/customers';
+import { invoices } from '../../data/agent-lab/invoices';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export async function getCustomer(customerNameOrId: string) {
+  await sleep(40);
+  const normalized = customerNameOrId.toLowerCase();
+  return customers.find(
+    customer => customer.id.toLowerCase() === normalized || customer.name.toLowerCase().includes(normalized),
+  );
+}
+
+export async function getCreditStatus(customerId: string) {
+  await sleep(40);
+  const customer = customers.find(item => item.id === customerId);
+  if (!customer) {
+    throw new Error(`Customer not found: ${customerId}`);
+  }
+
+  return {
+    customerId,
+    creditLimit: customer.creditLimit,
+    currentExposure: customer.currentExposure,
+    availableCredit: customer.creditLimit - customer.currentExposure,
+    status: customer.accountStatus,
+    riskLevel: customer.riskLevel,
+  };
+}
+
+export async function getOpenInvoices(customerId: string) {
+  await sleep(40);
+  return invoices.filter(invoice => invoice.customerId === customerId && invoice.status !== 'paid');
+}
+
+export async function createCreditReviewTicket(customerId: string, reason: string) {
+  await sleep(40);
+  return {
+    ticketId: `credit_${customerId}_${Date.now()}`,
+    customerId,
+    reason,
+    status: 'pending' as const,
+  };
+}

--- a/src/lib/agent-lab/policy.test.ts
+++ b/src/lib/agent-lab/policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateToolPermission } from './policy';
+
+describe('evaluateToolPermission', () => {
+  it('allows read-only get tools', () => {
+    expect(evaluateToolPermission('getCustomer', {})).toEqual({ decision: 'allow' });
+  });
+
+  it('requires approval for write tools', () => {
+    expect(evaluateToolPermission('createCreditReviewTicket', {})).toEqual({
+      decision: 'requires_approval',
+      reason: 'This tool creates a persistent business record.',
+    });
+  });
+
+  it('denies unknown tools', () => {
+    expect(evaluateToolPermission('deleteEverything', {})).toEqual({
+      decision: 'deny',
+      reason: 'Unknown or unsafe tool.',
+    });
+  });
+});

--- a/src/lib/agent-lab/policy.ts
+++ b/src/lib/agent-lab/policy.ts
@@ -1,0 +1,19 @@
+import type { ToolPermissionDecision } from './types';
+
+export function evaluateToolPermission(toolName: string, _args: unknown): { decision: ToolPermissionDecision; reason?: string } {
+  if (toolName.startsWith('get')) {
+    return { decision: 'allow' };
+  }
+
+  if (toolName === 'createCreditReviewTicket') {
+    return {
+      decision: 'requires_approval',
+      reason: 'This tool creates a persistent business record.',
+    };
+  }
+
+  return {
+    decision: 'deny',
+    reason: 'Unknown or unsafe tool.',
+  };
+}

--- a/src/lib/agent-lab/types.ts
+++ b/src/lib/agent-lab/types.ts
@@ -1,0 +1,54 @@
+export type RiskLevel = 'low' | 'medium' | 'high';
+export type AccountStatus = 'active' | 'blocked' | 'watchlist';
+
+export type Customer = {
+  id: string;
+  name: string;
+  creditLimit: number;
+  currentExposure: number;
+  paymentTerms: string;
+  riskLevel: RiskLevel;
+  accountStatus: AccountStatus;
+};
+
+export type Invoice = {
+  id: string;
+  customerId: string;
+  amount: number;
+  dueDate: string;
+  status: 'open' | 'paid' | 'overdue';
+  daysPastDue: number;
+};
+
+export type Scenario = {
+  id: string;
+  title: string;
+  customerName: string;
+  orderAmount: number;
+  userPrompt: string;
+};
+
+export type ToolPermissionDecision = 'allow' | 'requires_approval' | 'deny';
+
+export type TraceEvent = {
+  id: string;
+  type:
+    | 'user_message'
+    | 'model_response'
+    | 'tool_call'
+    | 'permission_check'
+    | 'tool_result'
+    | 'approval_required'
+    | 'final_answer'
+    | 'error';
+  title: string;
+  timestamp: number;
+  payload: unknown;
+  durationMs?: number;
+};
+
+export type RunResult = {
+  trace: TraceEvent[];
+  finalAnswer: string;
+  requiresApproval: boolean;
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,9 +22,10 @@ import Layout from '../layouts/Layout.astro';
 				<p class="text-slate-600 dark:text-slate-400">Learn accounting from scratch with interactive lessons, calculators, and real-world scenarios.</p>
 			</a>
 
-			<div class="p-6 bg-slate-100 dark:bg-slate-800/50 rounded-xl border border-slate-200 dark:border-slate-700 border-dashed flex items-center justify-center md:col-span-2">
-				<p class="text-slate-500 dark:text-slate-500">More tools coming soon...</p>
-			</div>
+			<a href="/tools/agent-lab" class="block p-6 bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-blue-400 dark:hover:border-blue-400 transition-colors transition-shadow hover:shadow-lg group md:col-span-2">
+				<h2 class="text-2xl font-bold mb-2 text-slate-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400">Agent Engineering Lab &rarr;</h2>
+				<p class="text-slate-600 dark:text-slate-400">Learn production AI agent concepts through interactive traces, tool calls, approvals, and mock ERP workflows.</p>
+			</a>
 		</div>
 	</div>
 </Layout>

--- a/src/pages/tools/agent-lab/index.astro
+++ b/src/pages/tools/agent-lab/index.astro
@@ -1,0 +1,8 @@
+---
+import AgentLabApp from '../../../components/agent-lab/AgentLabApp';
+import Layout from '../../../layouts/Layout.astro';
+---
+
+<Layout title="Agent Engineering Lab - Lifan Dev">
+  <AgentLabApp client:load />
+</Layout>


### PR DESCRIPTION
### Motivation
- Introduce an interactive, inspectable learning module that demonstrates production AI agent mechanics (messages, tool calls, permission checks, approvals, traceability) under `/tools/agent-lab`.
- Provide a deterministic, no-API-key-required MVP so the lab can be publicly browsed and used as a teaching/portfolio piece.
- Align with existing site structure and design patterns so the lab integrates as a React island inside the current Astro layout.

### Description
- Added a new route `src/pages/tools/agent-lab/index.astro` that mounts the React island `src/components/agent-lab/AgentLabApp.tsx` with `client:load`.
- Implemented core interactive UI components: `AgentLabApp.tsx`, `TraceTimeline.tsx`, `ToolCallPanel.tsx`, and `ApprovalGate.tsx` to support scenario selection, run control, trace rendering, payload inspection, and a human approval gate.
- Added deterministic agent runtime and policy layer in `src/lib/agent-lab/` with `types.ts`, `mockTools.ts`, `policy.ts`, and `agentRunner.ts` that produce `TraceEvent` sequences, simulate tool latency, enforce permission decisions (`allow` / `requires_approval` / `deny`), and create mock tickets when approved.
- Added local mock domain data in `src/data/agent-lab/` (`customers.ts`, `invoices.ts`, `scenarios.ts`) with three starter scenarios (ACME, Globex, Initech) used by the runner.
- Updated the homepage (`src/pages/index.astro`) to include an Agent Engineering Lab card linking to `/tools/agent-lab`.
- Added unit tests for the new pieces: `policy.test.ts`, `mockTools.test.ts`, and `agentRunner.test.ts` to validate permission logic, tools, and scenario outcomes.

### Testing
- Ran the test suite with `npm test` and all tests passed: 23 test files, 99 tests total (green).
- Added and ran tests covering `evaluateToolPermission`, mock tool behavior (`getCustomer`, `getCreditStatus`, `getOpenInvoices`), and deterministic scenario outcomes in `runScenario` (ACME requires approval, Globex auto-approves, Initech blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b8d4e0948329a8633118fbdf5c61)