### PR TITLE
Unify Agent Lab Navigation

### DIFF
--- a/src/components/agent-lab/AgentLabApp.test.tsx
+++ b/src/components/agent-lab/AgentLabApp.test.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import AgentLabApp from './AgentLabApp';
+
+afterEach(() => {
+  // Tests below mutate location.search; reset so subsequent tests start clean.
+  window.history.replaceState({}, '', '/');
+});
 
 describe('AgentLabApp', () => {
   it('runs the ACME scenario and completes the approval workflow', async () => {
@@ -117,5 +122,47 @@ describe('AgentLabApp', () => {
     expect(pre).not.toBeNull();
     expect(pre?.className).toMatch(/max-h-/);
     expect(pre?.className).toMatch(/overflow-auto/);
+  });
+
+  it('honors ?lens= on first paint to deep-link a specific tab', async () => {
+    window.history.replaceState({}, '', '/tools/agent-lab?lens=trace');
+    render(<AgentLabApp simulationLatencyMs={0} />);
+    const trace = await screen.findByRole('button', { name: /Trace Viewer/i });
+    await waitFor(() => {
+      expect(trace).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  it('updates the URL ?lens= query when the user changes tabs', async () => {
+    render(<AgentLabApp simulationLatencyMs={0} />);
+    fireEvent.click(screen.getByRole('button', { name: /^RAG$/i }));
+    await waitFor(() => {
+      expect(new URLSearchParams(window.location.search).get('lens')).toBe('rag');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Overview$/i }));
+    await waitFor(() => {
+      // Overview is the default and should clear the query param.
+      expect(new URLSearchParams(window.location.search).get('lens')).toBeNull();
+    });
+  });
+
+  it('groups the tab nav into Run, Lenses, and Mini-labs', async () => {
+    render(<AgentLabApp simulationLatencyMs={0} />);
+    // Wait for the realModelStatus useEffect to settle before asserting.
+    await screen.findByText(/test stub/i);
+    const nav = screen.getByRole('navigation', { name: /Agent Lab sections/i });
+    expect(nav.textContent).toMatch(/Run/);
+    expect(nav.textContent).toMatch(/Lenses/);
+    expect(nav.textContent).toMatch(/Mini-labs/);
+  });
+
+  it('renders the shared lab chrome with prev/next pagination', async () => {
+    render(<AgentLabApp simulationLatencyMs={0} />);
+    await screen.findByText(/test stub/i);
+    const chrome = screen.getByRole('navigation', { name: /Agent Lab navigation/i });
+    expect(chrome).toBeInTheDocument();
+    // The chrome includes a back-link to the labs index.
+    const backLink = screen.getByRole('link', { name: /All 12 labs/i });
+    expect(backLink).toHaveAttribute('href', '/tools/agent-lab/labs');
   });
 });

--- a/src/components/agent-lab/AgentLabApp.tsx
+++ b/src/components/agent-lab/AgentLabApp.tsx
@@ -23,6 +23,7 @@ import {
 import type { AgentRunResult, ApprovalDecision, TraceEvent } from '../../lib/agent-lab/types';
 import { ApprovalGate } from './ApprovalGate';
 import { ErrorBoundary } from './ErrorBoundary';
+import { LabChrome } from './LabChrome';
 import { EvalPanel } from './EvalPanel';
 import { LensConversation } from './lenses/LensConversation';
 import { LensLoop } from './lenses/LensLoop';
@@ -47,16 +48,46 @@ type LabTab =
   | 'evals'
   | 'rag';
 
-const tabs: Array<{ id: LabTab; label: string; description: string }> = [
-  { id: 'overview', label: 'Overview', description: 'Lesson summary and run controls' },
-  { id: 'llm', label: 'Conversation', description: 'User and model messages, no machinery' },
-  { id: 'structured', label: 'Structured Output', description: 'Schemas, validation, repair' },
-  { id: 'tools', label: 'Tool Calling', description: 'Typed tool registry and runtime calls' },
-  { id: 'loop', label: 'Agent Loop', description: 'Iteration-by-iteration view' },
-  { id: 'trace', label: 'Trace Viewer', description: 'Full event timeline + JSON inspector' },
-  { id: 'evals', label: 'Evals', description: 'Replay every case and score the agent' },
-  { id: 'rag', label: 'RAG', description: 'Compare uncited vs. retrieval-grounded answers' },
+type TabGroup = 'run' | 'lens' | 'mini';
+
+const tabs: Array<{ id: LabTab; label: string; description: string; group: TabGroup; lab: number }> = [
+  { id: 'overview', label: 'Overview', description: 'Lesson summary and run controls', group: 'run', lab: 10 },
+  { id: 'llm', label: 'Conversation', description: 'User and model messages, no machinery', group: 'lens', lab: 2 },
+  { id: 'structured', label: 'Structured Output', description: 'Schemas, validation, repair', group: 'lens', lab: 2 },
+  { id: 'tools', label: 'Tool Calling', description: 'Typed tool registry and runtime calls', group: 'lens', lab: 3 },
+  { id: 'loop', label: 'Agent Loop', description: 'Iteration-by-iteration view', group: 'lens', lab: 4 },
+  { id: 'trace', label: 'Trace Viewer', description: 'Full event timeline + JSON inspector', group: 'lens', lab: 11 },
+  { id: 'evals', label: 'Evals', description: 'Replay every case and score the agent', group: 'mini', lab: 9 },
+  { id: 'rag', label: 'RAG', description: 'Compare uncited vs. retrieval-grounded answers', group: 'mini', lab: 5 },
 ];
+
+const TAB_GROUPS: Array<{ id: TabGroup; label: string }> = [
+  { id: 'run', label: 'Run' },
+  { id: 'lens', label: 'Lenses' },
+  { id: 'mini', label: 'Mini-labs' },
+];
+
+const LENS_TAB_IDS: ReadonlyArray<LabTab> = [
+  'overview',
+  'llm',
+  'structured',
+  'tools',
+  'loop',
+  'trace',
+  'evals',
+  'rag',
+];
+
+function isLabTab(value: string | null): value is LabTab {
+  return value !== null && (LENS_TAB_IDS as ReadonlyArray<string>).includes(value);
+}
+
+function readLensFromUrl(): LabTab | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const lens = params.get('lens');
+  return isLabTab(lens) ? lens : null;
+}
 
 const overviewLesson = {
   title: 'Make the hidden loop visible',
@@ -119,6 +150,32 @@ export default function AgentLabApp({ simulationLatencyMs = 320 }: AgentLabAppPr
     };
   }, []);
 
+  // Honor ?lens=<tab> on first paint so deep-links from the labs index land
+  // on the requested lens. Subsequent tab clicks update the URL via
+  // history.replaceState so the link is shareable but no extra entry is
+  // pushed to history.
+  useEffect(() => {
+    const initial = readLensFromUrl();
+    if (initial) {
+      setActiveTab(initial);
+    }
+  }, []);
+
+  function changeTab(next: LabTab) {
+    setActiveTab(next);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (next === 'overview') {
+        url.searchParams.delete('lens');
+      } else {
+        url.searchParams.set('lens', next);
+      }
+      window.history.replaceState({}, '', url.toString());
+    }
+  }
+
+  const currentLab = tabs.find((tab) => tab.id === activeTab)?.lab ?? 2;
+
   async function runScenario(approvalDecision?: ApprovalDecision) {
     setIsRunning(true);
     try {
@@ -146,8 +203,10 @@ export default function AgentLabApp({ simulationLatencyMs = 320 }: AgentLabAppPr
   const events = result?.events ?? [];
 
   return (
-    <div className="mx-auto max-w-7xl space-y-8">
-      <section className="grid gap-8 py-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-end">
+    <div className="space-y-6">
+      <LabChrome current={currentLab} />
+      <div className="mx-auto max-w-7xl space-y-8">
+      <section className="grid gap-8 py-2 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-end">
         <div>
           <p className="text-sm font-medium uppercase tracking-normal text-slate-500 dark:text-slate-400">
             Production agents, inspected
@@ -159,12 +218,6 @@ export default function AgentLabApp({ simulationLatencyMs = 320 }: AgentLabAppPr
             A deterministic learning environment for tool boundaries, runtime schema validation,
             policy gates, and human approval — the parts of an AI agent the chatbot demos hide.
           </p>
-          <a
-            href="/tools/agent-lab/labs"
-            className="mt-4 inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-blue-700 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-300"
-          >
-            All 12 labs →
-          </a>
         </div>
         <div className="rounded-lg border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-800">
           <div className="flex items-start gap-3">
@@ -184,23 +237,40 @@ export default function AgentLabApp({ simulationLatencyMs = 320 }: AgentLabAppPr
 
       <nav
         aria-label="Agent Lab sections"
-        className="flex gap-2 overflow-x-auto border-b border-slate-200 pb-2 dark:border-slate-700"
+        className="flex flex-wrap gap-x-6 gap-y-3 border-b border-slate-200 pb-2 dark:border-slate-700"
       >
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setActiveTab(tab.id)}
-            aria-pressed={activeTab === tab.id}
-            className={`min-h-[44px] shrink-0 rounded-lg px-3 py-2 text-sm font-medium transition-colors motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
-              activeTab === tab.id
-                ? 'bg-blue-600 text-white'
-                : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+        {TAB_GROUPS.map((group) => {
+          const groupTabs = tabs.filter((tab) => tab.group === group.id);
+          if (groupTabs.length === 0) return null;
+          return (
+            <div key={group.id} className="flex items-center gap-2">
+              <span
+                className="text-[10px] font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500"
+                aria-hidden="true"
+              >
+                {group.label}
+              </span>
+              <div className="flex gap-1.5 overflow-x-auto">
+                {groupTabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => changeTab(tab.id)}
+                    aria-pressed={activeTab === tab.id}
+                    title={tab.description}
+                    className={`min-h-[44px] shrink-0 rounded-lg px-3 py-2 text-sm font-medium transition-colors motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                      activeTab === tab.id
+                        ? 'bg-blue-600 text-white'
+                        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50'
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </nav>
 
       <div className="grid gap-6 lg:grid-cols-[360px_minmax(0,1fr)]">
@@ -475,6 +545,7 @@ export default function AgentLabApp({ simulationLatencyMs = 320 }: AgentLabAppPr
           </section>
           </main>
         </ErrorBoundary>
+      </div>
       </div>
     </div>
   );

--- a/src/components/agent-lab/HybridSearchApp.tsx
+++ b/src/components/agent-lab/HybridSearchApp.tsx
@@ -8,6 +8,7 @@ import {
   type ScoredSection,
 } from '../../lib/agent-lab/hybridSearch';
 import { ErrorBoundary } from './ErrorBoundary';
+import { LabChrome } from './LabChrome';
 
 type HybridSearchAppProps = {
   initialQuery?: string;
@@ -56,8 +57,10 @@ export default function HybridSearchApp({
 
   return (
     <ErrorBoundary>
+      <div className="space-y-6">
+      <LabChrome current={6} />
       <div className="mx-auto max-w-7xl space-y-8">
-        <header className="space-y-3 py-6">
+        <header className="space-y-3 py-2">
           <p className="text-sm font-medium uppercase tracking-normal text-slate-500 dark:text-slate-400">
             Lab 6 · Retrieval signals, side by side
           </p>
@@ -148,6 +151,7 @@ export default function HybridSearchApp({
             ))}
           </ul>
         </section>
+      </div>
       </div>
     </ErrorBoundary>
   );

--- a/src/components/agent-lab/LabChrome.test.tsx
+++ b/src/components/agent-lab/LabChrome.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LabChrome } from './LabChrome';
+
+describe('LabChrome', () => {
+  it('renders position, theme tag, and a back-link to the labs index', () => {
+    render(<LabChrome current={6} />);
+    const nav = screen.getByRole('navigation', { name: /Agent Lab navigation/i });
+    expect(within(nav).getByText(/Lab 06 \/ 12/)).toBeInTheDocument();
+    expect(within(nav).getByText(/Retrieval/)).toBeInTheDocument();
+    const back = within(nav).getByRole('link', { name: /All 12 labs/i });
+    expect(back).toHaveAttribute('href', '/tools/agent-lab/labs');
+  });
+
+  it('links prev/next to the right neighbor labs in the catalog order', () => {
+    render(<LabChrome current={6} />);
+    const prev = screen.getByLabelText(/Previous lab: RAG/i);
+    expect(prev).toHaveAttribute('href', '/tools/agent-lab?lens=rag');
+    const next = screen.getByLabelText(/Next lab: MCP-style tool protocol/i);
+    expect(next).toHaveAttribute('href', '/tools/agent-lab/mcp-tools');
+  });
+
+  it('disables the prev link on the first lab', () => {
+    render(<LabChrome current={1} />);
+    const prev = screen.getByLabelText(/No previous lab/i);
+    expect(prev.tagName).toBe('SPAN');
+    expect(prev).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('skips external (docs-only) labs in pagination', () => {
+    render(<LabChrome current={11} />);
+    // Lab 12 is a docs-only external link, so the next button should be disabled.
+    const next = screen.getByLabelText(/No next lab/i);
+    expect(next).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/src/components/agent-lab/LabChrome.tsx
+++ b/src/components/agent-lab/LabChrome.tsx
@@ -1,0 +1,136 @@
+import { ArrowLeft, ArrowRight, LayoutGrid } from 'lucide-react';
+import { LABS, LAB_THEMES, getLabByNumber, type LabEntry } from '../../lib/agent-lab/labCatalog';
+
+type LabChromeProps = {
+  /**
+   * The 1-based lab number this page represents. For the canonical lab
+   * playground, callers should pass the lab number that matches the
+   * currently active lens (defaults to 2 — Structured outputs — when no
+   * lens is selected because that is the first canonical-lab card).
+   */
+  current: number;
+};
+
+/**
+ * Shared header strip rendered at the top of every lab page.
+ *
+ * Provides:
+ *  - a back-link to the 12-lab index
+ *  - the current position ("Lab 02 / 12")
+ *  - the theme tag
+ *  - prev / next navigation across the catalog
+ *
+ * Order is the canonical 1..12 sequence from labCatalog. External
+ * (docs-only) entries are skipped from prev/next so the strip never
+ * navigates the user away to GitHub by accident.
+ */
+export function LabChrome({ current }: LabChromeProps) {
+  const lab = getLabByNumber(current) ?? LABS[0];
+  const internalLabs = LABS.filter((entry) => !entry.external);
+  const indexInInternal = internalLabs.findIndex((entry) => entry.number === lab.number);
+
+  const prev = indexInInternal > 0 ? internalLabs[indexInInternal - 1] : undefined;
+  const next =
+    indexInInternal >= 0 && indexInInternal < internalLabs.length - 1
+      ? internalLabs[indexInInternal + 1]
+      : undefined;
+
+  const theme = LAB_THEMES[lab.theme];
+  const positionLabel = `Lab ${String(lab.number).padStart(2, '0')} / 12`;
+
+  return (
+    <nav
+      aria-label="Agent Lab navigation"
+      className="border-b border-slate-200 bg-white/80 py-3 backdrop-blur dark:border-slate-700 dark:bg-slate-900/60"
+    >
+      <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-1">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+          <a
+            href="/tools/agent-lab/labs"
+            className="inline-flex min-h-[36px] items-center gap-1 rounded-md px-2 py-1 font-medium text-slate-700 transition-colors motion-reduce:transition-none hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-slate-200 dark:hover:bg-slate-800 dark:hover:text-slate-50"
+          >
+            <LayoutGrid className="h-3.5 w-3.5" aria-hidden="true" />
+            All 12 labs
+          </a>
+          <span aria-hidden="true">·</span>
+          <span className="font-mono text-slate-700 dark:text-slate-200">{positionLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span
+            className="rounded-full bg-slate-100 px-2 py-0.5 font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+            title={theme.description}
+          >
+            {theme.label}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2" aria-label="Lab pagination">
+          <PrevNextLink lab={prev} direction="prev" />
+          <PrevNextLink lab={next} direction="next" />
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function PrevNextLink({
+  lab,
+  direction,
+}: {
+  lab: LabEntry | undefined;
+  direction: 'prev' | 'next';
+}) {
+  const ariaLabel =
+    direction === 'prev'
+      ? lab
+        ? `Previous lab: ${lab.title}`
+        : 'No previous lab'
+      : lab
+        ? `Next lab: ${lab.title}`
+        : 'No next lab';
+
+  const baseClass =
+    'inline-flex min-h-[36px] items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium transition-colors motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500';
+
+  if (!lab) {
+    return (
+      <span
+        aria-label={ariaLabel}
+        aria-disabled="true"
+        className={`${baseClass} cursor-not-allowed border-slate-200 text-slate-400 dark:border-slate-700 dark:text-slate-600`}
+      >
+        {direction === 'prev' ? (
+          <>
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+            Prev
+          </>
+        ) : (
+          <>
+            Next
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </>
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={lab.href}
+      aria-label={ariaLabel}
+      title={lab.title}
+      className={`${baseClass} border-slate-300 text-slate-700 hover:border-blue-400 hover:bg-slate-50 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-blue-500 dark:hover:bg-slate-800 dark:hover:text-slate-50`}
+    >
+      {direction === 'prev' ? (
+        <>
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          Lab {String(lab.number).padStart(2, '0')}
+        </>
+      ) : (
+        <>
+          Lab {String(lab.number).padStart(2, '0')}
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </>
+      )}
+    </a>
+  );
+}

--- a/src/components/agent-lab/LabsIndex.test.tsx
+++ b/src/components/agent-lab/LabsIndex.test.tsx
@@ -3,23 +3,41 @@ import { describe, expect, it } from 'vitest';
 import LabsIndex from './LabsIndex';
 
 describe('LabsIndex', () => {
-  it('renders all twelve labs', () => {
+  it('renders all twelve lab cards across the theme groups', () => {
     render(<LabsIndex />);
-    const list = screen.getByLabelText(/Agent Lab modules/i);
-    expect(list.querySelectorAll('li')).toHaveLength(12);
+    // Each lab card renders one h3 inside the modules list.
+    const cardHeadings = screen.getAllByRole('heading', { level: 3 });
+    expect(cardHeadings).toHaveLength(12);
+    // The outer <ol> exists with the labelled aria-label.
+    expect(screen.getByLabelText(/Agent Lab modules/i)).toBeInTheDocument();
+  });
+
+  it('groups labs by theme', () => {
+    render(<LabsIndex />);
+    expect(screen.getByRole('heading', { name: /^Foundations$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Retrieval$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Tooling$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Quality$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Safety$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Operations$/i })).toBeInTheDocument();
   });
 
   it('links Lab 1 to its dedicated route', () => {
     render(<LabsIndex />);
-    const link = screen
-      .getByRole('link', { name: /LLM API fundamentals/i });
+    const link = screen.getByRole('link', { name: /LLM API fundamentals/i });
     expect(link).toHaveAttribute('href', '/tools/agent-lab/llm-fundamentals');
   });
 
-  it('links the canonical-lab labs back to /tools/agent-lab', () => {
+  it('deep-links canonical-lab cards to the matching lens via ?lens=', () => {
     render(<LabsIndex />);
     const structuredOutputs = screen.getByRole('link', { name: /Structured outputs/i });
-    expect(structuredOutputs).toHaveAttribute('href', '/tools/agent-lab');
+    expect(structuredOutputs).toHaveAttribute('href', '/tools/agent-lab?lens=structured');
+
+    const toolCalling = screen.getByRole('link', { name: /Tool calling/i });
+    expect(toolCalling).toHaveAttribute('href', '/tools/agent-lab?lens=tools');
+
+    const evals = screen.getByRole('link', { name: /Evaluation harness/i });
+    expect(evals).toHaveAttribute('href', '/tools/agent-lab?lens=evals');
   });
 
   it('opens Lab 12 in a new tab as a docs link', () => {

--- a/src/components/agent-lab/LabsIndex.tsx
+++ b/src/components/agent-lab/LabsIndex.tsx
@@ -1,130 +1,14 @@
 import { ArrowRight } from 'lucide-react';
-
-type LabEntry = {
-  number: number;
-  title: string;
-  goal: string;
-  href: string;
-  hrefKind: 'route' | 'tab' | 'doc';
-  status: 'live' | 'docs-only';
-  /** What concrete artifact a visitor sees when they land. */
-  highlight: string;
-};
-
-const LABS: LabEntry[] = [
-  {
-    number: 1,
-    title: 'LLM API fundamentals',
-    goal: 'See the request/response loop the chat box hides.',
-    href: '/tools/agent-lab/llm-fundamentals',
-    hrefKind: 'route',
-    status: 'live',
-    highlight: 'Two side-by-side prompt configs with token usage, latency, and cost.',
-  },
-  {
-    number: 2,
-    title: 'Structured outputs',
-    goal: 'Make model output machine-readable and validate it.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'Structured Output lens: Zod schemas, validation errors, force-invalid toggle.',
-  },
-  {
-    number: 3,
-    title: 'Tool calling',
-    goal: 'See typed tool boundaries and runtime calls.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'Tool Calling lens: registry, args, results, all schema-validated.',
-  },
-  {
-    number: 4,
-    title: 'Agent loop',
-    goal: 'Watch a loop iterate, decide, and stop.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'Agent Loop lens: per-iteration view of the runner over the credit scenario.',
-  },
-  {
-    number: 5,
-    title: 'RAG',
-    goal: 'Compare uncited vs. retrieval-grounded answers.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'RAG lens: 8-section policy doc, deterministic keyword retrieval, citations.',
-  },
-  {
-    number: 6,
-    title: 'Hybrid search and reranking',
-    goal: 'See why a single retrieval signal is not enough.',
-    href: '/tools/agent-lab/hybrid-search',
-    hrefKind: 'route',
-    status: 'live',
-    highlight: 'BM25, pseudo-vector, RRF hybrid, and a toy reranker side by side.',
-  },
-  {
-    number: 7,
-    title: 'MCP-style tool protocol',
-    goal: 'Discover tools through a standard manifest.',
-    href: '/tools/agent-lab/mcp-tools',
-    hrefKind: 'route',
-    status: 'live',
-    highlight: 'Tool registry, JSON-schema inputs, permission badges, simulated handshake.',
-  },
-  {
-    number: 8,
-    title: 'Workflow vs free-form agent',
-    goal: 'Compare a fixed pipeline to an autonomous loop.',
-    href: '/tools/agent-lab/workflow-vs-agent',
-    hrefKind: 'route',
-    status: 'live',
-    highlight: 'Six-step deterministic workflow next to the free-form agent runner.',
-  },
-  {
-    number: 9,
-    title: 'Evaluation harness',
-    goal: 'Replay every case and score the agent.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'Evals lens: 8 canonical cases, per-assertion drill-down, metric strip.',
-  },
-  {
-    number: 10,
-    title: 'Human-in-the-loop',
-    goal: 'Classify actions by risk and approve / reject.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'Built into every run: write actions pause at the approval gate; rejection is first-class.',
-  },
-  {
-    number: 11,
-    title: 'Permissions and audit trails',
-    goal: 'Keep policy outside the model and log every decision.',
-    href: '/tools/agent-lab',
-    hrefKind: 'tab',
-    status: 'live',
-    highlight: 'Policy module + trace timeline: every iteration is a typed, inspectable event.',
-  },
-  {
-    number: 12,
-    title: 'Observability and deployment',
-    goal: 'Understand what production operation looks like.',
-    href: 'https://github.com/lifanh/lifan.dev/blob/main/docs/agent-lab-operations.md',
-    hrefKind: 'doc',
-    status: 'docs-only',
-    highlight: 'Operations doc: trace replay, cost / latency budgets, Cloudflare deployment notes.',
-  },
-];
+import {
+  LABS_BY_THEME,
+  LAB_THEMES,
+  type LabEntry,
+  type LabHrefKind,
+} from '../../lib/agent-lab/labCatalog';
 
 export default function LabsIndex() {
   return (
-    <div className="mx-auto max-w-7xl space-y-8">
+    <div className="mx-auto max-w-7xl space-y-10">
       <header className="space-y-3 py-6">
         <p className="text-sm font-medium uppercase tracking-normal text-slate-500 dark:text-slate-400">
           Agent Engineering Lab · 12 modules
@@ -134,61 +18,94 @@ export default function LabsIndex() {
         </h1>
         <p className="max-w-3xl text-lg leading-8 text-slate-600 dark:text-slate-300">
           Each lab is a focused playground for one concept in production AI agent engineering.
-          Eight share the canonical credit-order-eligibility scenario at <code>/tools/agent-lab</code>{' '}
-          (rendered as different lenses); four are dedicated routes for material that needed its
-          own surface area. One is documentation only because the topic is operational, not visual.
+          Seven share the canonical credit-order-eligibility scenario at <code>/tools/agent-lab</code>{' '}
+          (rendered as different lenses, deep-linked from the cards below); four are dedicated routes
+          for material that needed its own surface area. One is documentation only because the topic
+          is operational, not visual.
         </p>
       </header>
 
-      <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-label="Agent Lab modules">
-        {LABS.map((lab) => (
-          <li key={lab.number}>
-            <a
-              href={lab.href}
-              target={lab.hrefKind === 'doc' ? '_blank' : undefined}
-              rel={lab.hrefKind === 'doc' ? 'noreferrer' : undefined}
-              className="group block h-full rounded-lg border border-slate-200 bg-white p-5 transition-colors motion-reduce:transition-none hover:border-blue-400 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500 dark:hover:bg-slate-700"
-            >
-              <header className="flex items-baseline justify-between">
-                <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Lab {String(lab.number).padStart(2, '0')}
-                </span>
-                <KindBadge kind={lab.hrefKind} status={lab.status} />
-              </header>
-              <h2 className="mt-2 text-lg font-bold text-slate-900 dark:text-slate-50">{lab.title}</h2>
-              <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">{lab.goal}</p>
-              <p className="mt-3 text-xs leading-5 text-slate-500 dark:text-slate-400">{lab.highlight}</p>
-              <span className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-blue-700 dark:text-blue-300">
-                Open
-                <ArrowRight className="h-3.5 w-3.5 transition-transform motion-reduce:transition-none group-hover:translate-x-0.5" aria-hidden="true" />
+      <ol
+        className="space-y-10"
+        aria-label="Agent Lab modules"
+      >
+        {LABS_BY_THEME.map(({ theme, labs }) => (
+          <li key={theme} className="space-y-4">
+            <header className="flex flex-wrap items-baseline justify-between gap-2 border-b border-slate-200 pb-2 dark:border-slate-700">
+              <div>
+                <h2 className="text-xl font-bold text-slate-900 dark:text-slate-50">
+                  {LAB_THEMES[theme].label}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  {LAB_THEMES[theme].description}
+                </p>
+              </div>
+              <span className="text-xs font-mono uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                {labs.length} {labs.length === 1 ? 'lab' : 'labs'}
               </span>
-            </a>
+            </header>
+            <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {labs.map((lab) => (
+                <li key={lab.number}>
+                  <LabCard lab={lab} />
+                </li>
+              ))}
+            </ul>
           </li>
         ))}
       </ol>
 
       <section className="rounded-lg border border-slate-200 bg-slate-50 p-5 text-sm leading-6 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
         <strong className="font-medium text-slate-900 dark:text-slate-50">Why this layout:</strong>{' '}
-        Labs 2 / 3 / 4 / 5 / 9 / 10 / 11 are different lenses on a single, complete agent run, so they
-        share one route and the canonical scenario. Labs 1 / 6 / 7 / 8 introduce concepts the canonical
-        run does not exercise (the bare LLM protocol, alternative retrieval signals, the MCP tool
-        manifest, and a deterministic-workflow comparison) so they live as siblings. Lab 12 is a short
-        operations doc because production observability and deployment are infrastructure topics, not
-        a single visual demo.
+        Labs 2 / 3 / 4 / 5 / 9 / 10 / 11 are different lenses on a single, complete agent run, so
+        they share one route and the canonical scenario — each card deep-links to the right lens
+        via a query parameter. Labs 1 / 6 / 7 / 8 introduce concepts the canonical run does not
+        exercise (the bare LLM protocol, alternative retrieval signals, the MCP tool manifest, and
+        a deterministic-workflow comparison) so they live as siblings. Lab 12 is a short operations
+        doc because production observability and deployment are infrastructure topics, not a single
+        visual demo.
       </section>
     </div>
   );
 }
 
-function KindBadge({ kind, status }: { kind: LabEntry['hrefKind']; status: LabEntry['status'] }) {
-  if (status === 'docs-only') {
+function LabCard({ lab }: { lab: LabEntry }) {
+  return (
+    <a
+      href={lab.href}
+      target={lab.external ? '_blank' : undefined}
+      rel={lab.external ? 'noreferrer' : undefined}
+      className="group block h-full rounded-lg border border-slate-200 bg-white p-5 transition-colors motion-reduce:transition-none hover:border-blue-400 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500 dark:hover:bg-slate-700"
+    >
+      <header className="flex items-baseline justify-between">
+        <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Lab {String(lab.number).padStart(2, '0')}
+        </span>
+        <KindBadge kind={lab.hrefKind} />
+      </header>
+      <h3 className="mt-2 text-lg font-bold text-slate-900 dark:text-slate-50">{lab.title}</h3>
+      <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">{lab.goal}</p>
+      <p className="mt-3 text-xs leading-5 text-slate-500 dark:text-slate-400">{lab.highlight}</p>
+      <span className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-blue-700 dark:text-blue-300">
+        Open
+        <ArrowRight
+          className="h-3.5 w-3.5 transition-transform motion-reduce:transition-none group-hover:translate-x-0.5"
+          aria-hidden="true"
+        />
+      </span>
+    </a>
+  );
+}
+
+function KindBadge({ kind }: { kind: LabHrefKind }) {
+  if (kind === 'doc') {
     return (
       <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
         docs
       </span>
     );
   }
-  if (kind === 'tab') {
+  if (kind === 'canonical') {
     return (
       <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-900 dark:bg-amber-900/40 dark:text-amber-100">
         canonical lab

--- a/src/components/agent-lab/LlmFundamentalsApp.tsx
+++ b/src/components/agent-lab/LlmFundamentalsApp.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { callSimulatedLlm, type LlmRequest, type LlmResponse } from '../../lib/agent-lab/llmSimulator';
 import { ErrorBoundary } from './ErrorBoundary';
+import { LabChrome } from './LabChrome';
 
 const DEFAULT_SYSTEM = 'You are a careful credit-risk analyst. Respond with concrete next actions.';
 const DEFAULT_USER = 'Summarise how blocked accounts and overdue invoices interact for order eligibility.';
@@ -39,8 +40,10 @@ export default function LlmFundamentalsApp() {
 
   return (
     <ErrorBoundary>
+      <div className="space-y-6">
+      <LabChrome current={1} />
       <div className="mx-auto max-w-7xl space-y-8">
-        <header className="space-y-3 py-6">
+        <header className="space-y-3 py-2">
           <p className="text-sm font-medium uppercase tracking-normal text-slate-500 dark:text-slate-400">
             Lab 1 · LLM API fundamentals
           </p>
@@ -96,6 +99,7 @@ export default function LlmFundamentalsApp() {
           contract, not afterthoughts; latency, cost, and output variance are visible from day one,
           not surfaced only when something breaks in production.
         </section>
+      </div>
       </div>
     </ErrorBoundary>
   );

--- a/src/components/agent-lab/McpToolsApp.tsx
+++ b/src/components/agent-lab/McpToolsApp.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../lib/agent-lab/mcpManifest';
 import type { ToolName } from '../../lib/agent-lab/schemas';
 import { ErrorBoundary } from './ErrorBoundary';
+import { LabChrome } from './LabChrome';
 
 const PERMISSION_BADGE: Record<McpToolDescriptor['permission']['level'], { label: string; tone: string }> = {
   read_only: {
@@ -46,8 +47,10 @@ export default function McpToolsApp() {
 
   return (
     <ErrorBoundary>
+      <div className="space-y-6">
+      <LabChrome current={7} />
       <div className="mx-auto max-w-7xl space-y-8">
-        <header className="space-y-3 py-6">
+        <header className="space-y-3 py-2">
           <p className="text-sm font-medium uppercase tracking-normal text-slate-500 dark:text-slate-400">
             Lab 7 · MCP-style tool protocol
           </p>
@@ -113,6 +116,7 @@ export default function McpToolsApp() {
             <HandshakePanel handshake={handshake} />
           </div>
         </section>
+      </div>
       </div>
     </ErrorBoundary>
   );

--- a/src/components/agent-lab/WorkflowApp.tsx
+++ b/src/components/agent-lab/WorkflowApp.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../lib/agent-lab/workflow';
 import type { AgentRunResult, ApprovalDecision } from '../../lib/agent-lab/types';
 import { ErrorBoundary } from './ErrorBoundary';
+import { LabChrome } from './LabChrome';
 
 const STATUS_ICON: Record<WorkflowStepStatus, { Icon: typeof CheckCircle2; tone: string; label: string }> = {
   ok: { Icon: CheckCircle2, tone: 'text-emerald-600 dark:text-emerald-400', label: 'completed' },
@@ -51,8 +52,10 @@ export default function WorkflowApp() {
 
   return (
     <ErrorBoundary>
+      <div className="space-y-6">
+      <LabChrome current={8} />
       <div className="mx-auto max-w-7xl space-y-8">
-        <header className="space-y-3 py-6">
+        <header className="space-y-3 py-2">
           <p className="text-sm font-medium uppercase tracking-normal text-slate-500 dark:text-slate-400">
             Lab 8 · Workflow vs free-form agent
           </p>
@@ -145,6 +148,7 @@ export default function WorkflowApp() {
           unknown, costly when the task shape is known up front. Most production "agents" are a hybrid:
           deterministic outer loop, model-shaped inner steps.
         </section>
+      </div>
       </div>
     </ErrorBoundary>
   );

--- a/src/lib/agent-lab/labCatalog.ts
+++ b/src/lib/agent-lab/labCatalog.ts
@@ -1,0 +1,202 @@
+/**
+ * Single source of truth for the 12 Agent Lab modules.
+ *
+ * Consumed by LabsIndex (the card grid) and LabChrome (the breadcrumb /
+ * prev-next strip rendered on every lab page) so that lab metadata,
+ * theme grouping, and deep-link targets stay in sync.
+ */
+
+export type LabTheme =
+  | 'foundations'
+  | 'retrieval'
+  | 'tooling'
+  | 'quality'
+  | 'safety'
+  | 'operations';
+
+export type LabHrefKind = 'route' | 'canonical' | 'doc';
+
+/**
+ * A canonical-lab entry deep-links into a specific lens of the canonical
+ * /tools/agent-lab playground. We model the lens as a query parameter
+ * (?lens=...) consumed by AgentLabApp.
+ */
+export type LabEntry = {
+  number: number;
+  title: string;
+  goal: string;
+  /** Concrete artifact a visitor sees when they land. */
+  highlight: string;
+  theme: LabTheme;
+  hrefKind: LabHrefKind;
+  /** Final URL a visitor follows. Includes ?lens=... for canonical labs. */
+  href: string;
+  /** True if `href` should open in a new tab. */
+  external?: boolean;
+};
+
+export const LAB_THEMES: Record<LabTheme, { label: string; description: string }> = {
+  foundations: {
+    label: 'Foundations',
+    description: 'Messages, schemas, tools, the loop itself, and retrieval.',
+  },
+  retrieval: {
+    label: 'Retrieval',
+    description: 'Why a single retrieval signal is rarely enough.',
+  },
+  tooling: {
+    label: 'Tooling',
+    description: 'Tool discovery and the workflow / agent boundary.',
+  },
+  quality: {
+    label: 'Quality',
+    description: 'Replay, score, and regression-test agent behavior.',
+  },
+  safety: {
+    label: 'Safety',
+    description: 'Human approval and policy outside the model.',
+  },
+  operations: {
+    label: 'Operations',
+    description: 'What production deployment and observability look like.',
+  },
+};
+
+export const LABS: LabEntry[] = [
+  {
+    number: 1,
+    title: 'LLM API fundamentals',
+    goal: 'See the request/response loop the chat box hides.',
+    highlight: 'Two side-by-side prompt configs with token usage, latency, and cost.',
+    theme: 'foundations',
+    hrefKind: 'route',
+    href: '/tools/agent-lab/llm-fundamentals',
+  },
+  {
+    number: 2,
+    title: 'Structured outputs',
+    goal: 'Make model output machine-readable and validate it.',
+    highlight: 'Structured Output lens: Zod schemas, validation errors, force-invalid toggle.',
+    theme: 'foundations',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=structured',
+  },
+  {
+    number: 3,
+    title: 'Tool calling',
+    goal: 'See typed tool boundaries and runtime calls.',
+    highlight: 'Tool Calling lens: registry, args, results, all schema-validated.',
+    theme: 'foundations',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=tools',
+  },
+  {
+    number: 4,
+    title: 'Agent loop',
+    goal: 'Watch a loop iterate, decide, and stop.',
+    highlight: 'Agent Loop lens: per-iteration view of the runner over the credit scenario.',
+    theme: 'foundations',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=loop',
+  },
+  {
+    number: 5,
+    title: 'RAG',
+    goal: 'Compare uncited vs. retrieval-grounded answers.',
+    highlight: 'RAG lens: 8-section policy doc, deterministic keyword retrieval, citations.',
+    theme: 'foundations',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=rag',
+  },
+  {
+    number: 6,
+    title: 'Hybrid search and reranking',
+    goal: 'See why a single retrieval signal is not enough.',
+    highlight: 'BM25, pseudo-vector, RRF hybrid, and a toy reranker side by side.',
+    theme: 'retrieval',
+    hrefKind: 'route',
+    href: '/tools/agent-lab/hybrid-search',
+  },
+  {
+    number: 7,
+    title: 'MCP-style tool protocol',
+    goal: 'Discover tools through a standard manifest.',
+    highlight: 'Tool registry, JSON-schema inputs, permission badges, simulated handshake.',
+    theme: 'tooling',
+    hrefKind: 'route',
+    href: '/tools/agent-lab/mcp-tools',
+  },
+  {
+    number: 8,
+    title: 'Workflow vs free-form agent',
+    goal: 'Compare a fixed pipeline to an autonomous loop.',
+    highlight: 'Six-step deterministic workflow next to the free-form agent runner.',
+    theme: 'tooling',
+    hrefKind: 'route',
+    href: '/tools/agent-lab/workflow-vs-agent',
+  },
+  {
+    number: 9,
+    title: 'Evaluation harness',
+    goal: 'Replay every case and score the agent.',
+    highlight: 'Evals lens: 8 canonical cases, per-assertion drill-down, metric strip.',
+    theme: 'quality',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=evals',
+  },
+  {
+    number: 10,
+    title: 'Human-in-the-loop',
+    goal: 'Classify actions by risk and approve / reject.',
+    highlight: 'Built into every run: write actions pause at the approval gate; rejection is first-class.',
+    theme: 'safety',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=overview',
+  },
+  {
+    number: 11,
+    title: 'Permissions and audit trails',
+    goal: 'Keep policy outside the model and log every decision.',
+    highlight: 'Policy module + trace timeline: every iteration is a typed, inspectable event.',
+    theme: 'safety',
+    hrefKind: 'canonical',
+    href: '/tools/agent-lab?lens=trace',
+  },
+  {
+    number: 12,
+    title: 'Observability and deployment',
+    goal: 'Understand what production operation looks like.',
+    highlight: 'Operations doc: trace replay, cost / latency budgets, Cloudflare deployment notes.',
+    theme: 'operations',
+    hrefKind: 'doc',
+    href: 'https://github.com/lifanh/lifan.dev/blob/main/docs/agent-lab-operations.md',
+    external: true,
+  },
+];
+
+/** Ordered list of (theme, labs) for grouped rendering on the labs index. */
+export const LABS_BY_THEME: Array<{ theme: LabTheme; labs: LabEntry[] }> = (
+  Object.keys(LAB_THEMES) as LabTheme[]
+).map((theme) => ({
+  theme,
+  labs: LABS.filter((lab) => lab.theme === theme),
+}));
+
+export function getLabByNumber(n: number): LabEntry | undefined {
+  return LABS.find((lab) => lab.number === n);
+}
+
+/**
+ * Find the lab entry that owns a given pathname (ignoring query/hash).
+ * Canonical entries collapse to the single /tools/agent-lab pathname; in
+ * that case the *first* canonical entry is returned and callers that need
+ * a more specific position must pass an explicit lab number.
+ */
+export function getLabByPath(pathname: string): LabEntry | undefined {
+  const stripped = pathname.replace(/\/+$/, '');
+  return LABS.find((lab) => {
+    if (lab.external) return false;
+    const labPath = lab.href.split('?')[0].replace(/\/+$/, '');
+    return labPath === stripped;
+  });
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,13 @@ import Layout from '../layouts/Layout.astro';
 				<p class="text-slate-600 dark:text-slate-400">Learn accounting from scratch with interactive lessons, calculators, and real-world scenarios.</p>
 			</a>
 
-			<div class="p-6 bg-slate-100 dark:bg-slate-800/50 rounded-xl border border-slate-200 dark:border-slate-700 border-dashed flex items-center justify-center md:col-span-2">
+			<a href="/tools/agent-lab/labs" class="block p-6 bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-blue-400 dark:hover:border-blue-400 transition-colors transition-shadow hover:shadow-lg group">
+				<h2 class="text-2xl font-bold mb-2 text-slate-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400">Agent Engineering Lab &rarr;</h2>
+				<p class="text-slate-600 dark:text-slate-400">Twelve focused labs on production AI agent engineering: messages, schemas, tools, the loop, retrieval, MCP, evals, approvals, and operations.</p>
+				<span class="mt-3 inline-block text-sm font-medium text-blue-700 dark:text-blue-300">Browse all 12 labs &rarr;</span>
+			</a>
+
+			<div class="p-6 bg-slate-100 dark:bg-slate-800/50 rounded-xl border border-slate-200 dark:border-slate-700 border-dashed flex items-center justify-center">
 				<p class="text-slate-500 dark:text-slate-500">More tools coming soon...</p>
 			</div>
 		</div>


### PR DESCRIPTION
This pull request introduces a new shared `LabChrome` component to unify and improve the navigation and header experience across all Agent Lab modules. It also enhances tab navigation, deep-linking, and grouping in the Agent Lab playground, and updates tests to reflect these changes. The most important changes are summarized below.

**Navigation and Header Improvements:**

- Added a new `LabChrome` component that renders a consistent header strip at the top of every lab page, including the lab's position, theme tag, a back-link to the lab index, and prev/next navigation that skips external (docs-only) labs. (`src/components/agent-lab/LabChrome.tsx`, `src/components/agent-lab/LabChrome.test.tsx`) [[1]](diffhunk://#diff-36b86c29cf1b5c8cb425d5eab3bdfde63fa0a623c5f341722e906a0b70677e98R1-R136) [[2]](diffhunk://#diff-4df96d2c1a48eb1193412b8518a2d2c1fede0e2d986c49c3a3d1bc6cd0c61ed4R1-R36)
- Integrated `LabChrome` into both the canonical Agent Lab playground (`AgentLabApp`) and the Hybrid Search lab app for a consistent look and navigation experience. (`src/components/agent-lab/AgentLabApp.tsx`, `src/components/agent-lab/HybridSearchApp.tsx`) [[1]](diffhunk://#diff-8f67bcec40419182f352b190b87d781376fc29219c147abf80adf35d08328e7bR206-R209) [[2]](diffhunk://#diff-0cad774123ac2ecadd1cd6e9d730923a5077bf0df2280471ab4c68eadb3f2a56R60-R63)

**Tab Navigation and Deep-Linking Enhancements:**

- Refactored tab navigation in `AgentLabApp` to group tabs into "Run", "Lenses", and "Mini-labs", and to support deep-linking to specific tabs via the `?lens=` query parameter. Tab changes now update the URL for shareable deep links. (`src/components/agent-lab/AgentLabApp.tsx`) [[1]](diffhunk://#diff-8f67bcec40419182f352b190b87d781376fc29219c147abf80adf35d08328e7bL50-R91) [[2]](diffhunk://#diff-8f67bcec40419182f352b190b87d781376fc29219c147abf80adf35d08328e7bR153-R178) [[3]](diffhunk://#diff-8f67bcec40419182f352b190b87d781376fc29219c147abf80adf35d08328e7bL187-R260)
- Added and updated tests to verify deep-linking, tab groupings, and URL updates when switching tabs. (`src/components/agent-lab/AgentLabApp.test.tsx`)

**Lab Index and Linking Updates:**

- Updated the Labs Index to group labs by theme, verify correct grouping in tests, and ensure canonical labs link directly to the correct playground lens via `?lens=`. (`src/components/agent-lab/LabsIndex.test.tsx`)

**Test and Cleanup Improvements:**

- Improved test isolation by resetting the browser URL after each test in `AgentLabApp.test.tsx`.

These changes collectively improve navigation, discoverability, and test coverage across the Agent Lab experience.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifanh/lifan.dev/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->